### PR TITLE
feat: Automate database setup in regression test script

### DIFF
--- a/.github-offline/db.config.php
+++ b/.github-offline/db.config.php
@@ -1,0 +1,15 @@
+<?php
+
+  // Database access definition
+  $dbserver     = "127.0.0.1"; // your database hostname
+  $dbname       = "addressbook";      // your database name
+  $dbuser       = "root";      // your database username
+  $dbpass       = "root";          // your database password
+
+  // You may use a table-prefix if you have only one DB-User
+  $table_prefix = "";
+
+  // Keep a history of all changes, incl. deletion. Used for intelligent merge.
+  $keep_history = true;
+
+?>

--- a/.github-offline/regression-tests.sh
+++ b/.github-offline/regression-tests.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+# --- Pre-requisites ---
+# 1. PHP 5.4 installed and in your PATH.
+# 2. MySQL 5.5 server running.
+# 3. A MySQL user 'root' with password 'root' having administrative privileges.
+
+# --- Test Environment Setup ---
+
+# 1. Setup Database
+echo "Setting up the test database..."
+mysql -u root -proot -e "DROP DATABASE IF EXISTS addressbook;"
+mysql -u root -proot -e "CREATE DATABASE addressbook;"
+mysql -u root -proot addressbook < addressbook.sql
+
+# 2. Configure Database
+echo "Configuring database..."
+cp .github-offline/db.config.php config/cfg.db.php
+
+# 3. Start PHP 5.4 Web Server
+echo "Starting PHP 5.4 web server on localhost:8000..."
+php -S localhost:8000 -t . &
+PHP_SERVER_PID=$!
+sleep 2 # Give the server a moment to start
+
+# --- Test Execution ---
+
+# 4. Set SERVER variables and run tests
+echo "Running tests..."
+export SERVER_NAME="localhost:8000"
+export REQUEST_URI="/index.php"
+php test/index.php
+
+# --- Cleanup ---
+
+# 5. Stop PHP Web Server
+echo "Stopping PHP web server..."
+kill $PHP_SERVER_PID

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,28 @@
+# Agent Instructions
+
+This document provides instructions for agents working on this codebase.
+
+## Offline Regression Testing
+
+To run the full test suite in an environment that mimics the CI setup, you can use the `regression-tests.sh` script. This script automates the test environment setup, including the database.
+
+**Prerequisites:**
+
+*   **PHP 5.4:** You must have PHP 5.4 installed and available in your system's PATH.
+*   **MySQL 5.5:** A MySQL 5.5 server must be running.
+*   **Database User:** A MySQL user named `root` with the password `root` must exist and have privileges to create and drop databases.
+
+**Usage:**
+
+```bash
+bash .github-offline/regression-tests.sh
+```
+
+The script will handle the following:
+
+1.  Drop and recreate the `addressbook` test database.
+2.  Import the database schema.
+3.  Configure the application to use the test database.
+4.  Start a temporary PHP built-in web server.
+5.  Run the SimpleTest suite.
+6.  Stop the web server.


### PR DESCRIPTION
Updates the offline regression testing script to automatically handle database setup.

- The `regression-tests.sh` script now drops, creates, and seeds the `addressbook` database before running tests.
- The `AGENTS.md` file has been updated to reflect the new automated database setup process, simplifying the prerequisites for developers.