### PR TITLE
feat: Replace Travis CI with GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,42 @@
+name: CI
+
+on: [push]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        php-versions: ['5.4', '5.5', '7.0']
+
+    services:
+      mysql:
+        image: mysql:5.5
+        env:
+          MYSQL_ROOT_PASSWORD: root
+        ports:
+          - 3306:3306
+        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Setup PHP
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: ${{ matrix.php-versions }}
+        extensions: mysqli
+
+    - name: Setup Database
+      run: |
+        mysql -h 127.0.0.1 -u root -proot -e "CREATE DATABASE addressbook;"
+        mysql -h 127.0.0.1 -u root -proot addressbook < addressbook.sql
+
+    - name: Run tests
+      run: |
+        cp .github-offline/db.config.php config/cfg.db.php
+        php -S localhost:8000 -t . &
+        sleep 5
+        export SERVER_NAME="localhost:8000"
+        export REQUEST_URI="/index.php"
+        php test/index.php

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,0 @@
-language: php
-php:
-- 5.5
-- 5.4
-- 7.0
-services: mysql
-script: phpunit test/index.php


### PR DESCRIPTION
This commit replaces the outdated and non-functional Travis CI configuration with a new GitHub Actions workflow.

The new workflow automatically runs the test suite on every push to any branch, testing against a matrix of PHP versions (5.4, 5.5, and 7.0) and MySQL 5.5.

The workflow is based on the existing offline regression testing script, ensuring consistency between local and CI environments.