### PR TITLE
Add automated regression test via GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,50 @@
+name: CI
+
+on:
+  push:
+    branches: [ "*" ]
+  pull_request:
+    branches: [ "*" ]
+
+jobs:
+  test:
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        php: [ '5.4', '5.5', '5.6', '7.0' ]
+
+    services:
+      mysql:
+        image: mysql:5.5
+        env:
+          MYSQL_ROOT_PASSWORD: root
+        ports:
+          - 3306:3306
+        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix: php }}
+          extensions: ${{ matrix.php == '7.0' && 'mysqli' || 'mysql, mysqli' }}
+          ini-values: error_reporting=E_ALL
+
+      - name: Install MySQL client
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y mysql-client
+
+      - name: Run regression tests
+        run: |
+          # Create a wrapper for mysql to use the service container and password
+          # Use absolute path to /usr/bin/mysql to avoid infinite recursion
+          echo '#!/bin/bash' > /tmp/mysql
+          echo '/usr/bin/mysql -h 127.0.0.1 -u root -proot "$@"' >> /tmp/mysql
+          chmod +x /tmp/mysql
+          export PATH=/tmp:$PATH
+
+          bash .github-offline/regression-tests.sh


### PR DESCRIPTION
This change adds a GitHub Actions workflow to automate the project's regression tests. 

Key features:
- **Comprehensive Matrix**: Tests against PHP 5.4, 5.5, 5.6, and 7.0 to ensure compatibility across supported versions.
- **Legacy Support**: Correctly handles PHP extensions by including `mysql` for older versions and `mysqli` for all versions.
- **Service Orchestration**: Sets up a MySQL 5.5 service container as required by the project's legacy environment.
- **Non-Invasive Integration**: Implements a `mysql` CLI wrapper within the CI job to bridge the gap between the existing `regression-tests.sh` script and the GitHub Actions service container environment. This avoids any modifications to the original source code or test scripts.
- **Robustness**: Uses absolute paths in the wrapper to prevent recursion and ensures appropriate wait times for service health.

Fixes #29

---
*PR created automatically by Jules for task [7217499116865781150](https://jules.google.com/task/7217499116865781150) started by @chatelao*