### PR TITLE
Implement screenshot uniqueness verification and improve test data setup

### DIFF
--- a/.github-offline/regression-tests.sh
+++ b/.github-offline/regression-tests.sh
@@ -12,6 +12,7 @@ echo "Setting up the test database..."
 mysql -u root -proot -e "DROP DATABASE IF EXISTS addressbook;"
 mysql -u root -proot -e "CREATE DATABASE addressbook;"
 mysql -u root -proot addressbook < addressbook.sql
+mysql -u root -proot addressbook < test/sample_data.sql
 
 # 2. Configure Database
 echo "Configuring database..."

--- a/.github/verify_frontend.py
+++ b/.github/verify_frontend.py
@@ -54,6 +54,38 @@ def test_views(page: Page):
     capture_view(page, "/view.php", "view_page")
     expect(page.locator('body')).to_contain_text("PRINT_ALL")
 
+    # View specific contact
+    capture_view(page, "/view.php?id=1", "view_contact_1")
+    expect(page.locator('body')).to_contain_text("John")
+
+def verify_screenshots():
+    import hashlib
+    import os
+
+    print("\nVerifying screenshots...")
+    files = sorted([f for f in os.listdir('verification') if f.endswith('.png')])
+    hashes = {}
+    for f in files:
+        with open(os.path.join('verification', f), 'rb') as f_in:
+            h = hashlib.md5(f_in.read()).hexdigest()
+            hashes[f] = h
+            print(f"{f}: {h}")
+
+    seen = {}
+    duplicates = []
+    for f, h in hashes.items():
+        if h in seen:
+            duplicates.append((f, seen[h]))
+        seen[h] = f
+
+    if duplicates:
+        print("\nERROR: Duplicate screenshots found!")
+        for d in duplicates:
+            print(f"  - {d[0]} is a duplicate of {d[1]}")
+        exit(1)
+    else:
+        print("\nSUCCESS: No duplicate screenshots found.")
+
 if __name__ == "__main__":
     with sync_playwright() as p:
         browser = p.chromium.launch(headless=True)
@@ -62,5 +94,6 @@ if __name__ == "__main__":
         page = context.new_page()
         try:
             test_views(page)
+            verify_screenshots()
         finally:
             browser.close()

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 node_modules/
+verification/
+server.log
+cookies.txt

--- a/test/sample_data.sql
+++ b/test/sample_data.sql
@@ -1,0 +1,44 @@
+-- Add a sample contact
+SET SQL_MODE='';
+INSERT INTO `addressbook` (
+    `domain_id`, `id`, `firstname`, `middlename`, `lastname`, `nickname`,
+    `company`, `title`, `address`, `home`, `mobile`, `work`, `fax`,
+    `email`, `email2`, `email3`, `im`, `im2`, `im3`, `homepage`,
+    `bday`, `bmonth`, `byear`, `aday`, `amonth`, `ayear`,
+    `address2`, `phone2`, `notes`, `created`, `modified`, `deprecated`
+) VALUES (
+    0, 1, 'John', 'Q.', 'Doe', 'JD',
+    'ACME Corp', 'Engineer', '123 Main St\nAnytown, USA', '555-1212', '555-1313', '555-1414', '555-1515',
+    'john.doe@example.com', 'jd@example.org', '', '', '', '', 'http://example.com/~jdoe',
+    15, 'January', '1980', 1, 'January', '2010',
+    'Secondary Address', '555-2222', 'Notes about John Doe', NOW(), NOW(), '0000-00-00 00:00:00'
+);
+
+-- Add another sample contact for birthday variety
+INSERT INTO `addressbook` (
+    `domain_id`, `id`, `firstname`, `middlename`, `lastname`, `nickname`,
+    `company`, `title`, `address`, `home`, `mobile`, `work`, `fax`,
+    `email`, `email2`, `email3`, `im`, `im2`, `im3`, `homepage`,
+    `bday`, `bmonth`, `byear`, `aday`, `amonth`, `ayear`,
+    `address2`, `phone2`, `notes`, `created`, `modified`, `deprecated`
+) VALUES (
+    0, 2, 'Jane', 'M.', 'Smith', 'JS',
+    'Globex', 'Manager', '456 Elm St\nOthertown, USA', '555-3333', '555-4444', '', '',
+    'jane.smith@example.com', '', '', '', '', '', '',
+    20, 'February', '1985', 0, '', '',
+    '', '', 'Notes about Jane', NOW(), NOW(), '0000-00-00 00:00:00'
+);
+
+-- Add a sample group
+INSERT INTO `group_list` (
+    `domain_id`, `group_id`, `group_name`, `group_header`, `group_footer`, `created`, `modified`, `deprecated`
+) VALUES (
+    0, 1, 'Test Group', 'Header for Test Group', 'Footer for Test Group', NOW(), NOW(), '0000-00-00 00:00:00'
+);
+
+-- Assign John Doe to Test Group
+INSERT INTO `address_in_groups` (
+    `domain_id`, `id`, `group_id`, `created`, `modified`, `deprecated`
+) VALUES (
+    0, 1, 1, NOW(), NOW(), '0000-00-00 00:00:00'
+);


### PR DESCRIPTION
This change addresses the issue where frontend verification tests might capture the same screen repeatedly without failing. 

Key improvements:
1. **Uniqueness Verification**: The `.github/verify_frontend.py` script now computes MD5 hashes of all captured screenshots and fails the test if any duplicates are found.
2. **Realistic Test Data**: A new `test/sample_data.sql` file provides a baseline set of contacts and groups. This ensures that the Home, Groups, Birthdays, and View pages have distinct visual content.
3. **Automated Setup**: The regression test script now automatically loads this sample data, making the test environment more robust.
4. **Clean Repository**: Updated `.gitignore` to prevent accidental commitment of logs and screenshots.

Fixes #50

---
*PR created automatically by Jules for task [12281860509847908968](https://jules.google.com/task/12281860509847908968) started by @chatelao*