### PR TITLE
Create ROADMAP.md and centralize project tasks

### DIFF
--- a/CONCEPT.md
+++ b/CONCEPT.md
@@ -52,21 +52,4 @@ The application follows a classic LAMP stack pattern with integrated specialized
 
 ## Roadmap
 
-The following tasks are prioritized for modernization and technical debt reduction:
-
-### Phase 1: Dependency Modernization
-- [ ] Upgrade **jQuery** from 1.8.2 to 3.7.x.
-- [ ] Upgrade **DataTables** from 1.9.4 to 2.x.
-- [ ] Replace **PHP Excel Reader** with **PhpSpreadsheet**.
-- [ ] Upgrade **HybridAuth** to 3.x.
-- [ ] Upgrade **Z-Push** to 2.7.x.
-
-### Phase 2: Core Improvements
-- [ ] **PHP 8.x Native Support**: Resolve all remaining incompatibilities in the core and testing framework.
-- [ ] **Responsive UI**: Implement a mobile-first responsive design using modern CSS.
-- [ ] **Database Layer Refactor**: Transition from the `mysql_shim.php` to native `mysqli` or a modern ORM/Query Builder.
-
-### Phase 3: Technical Debt Cleanup
-- [ ] Remove **MooTools** and migrate `jscalendar` to a modern date picker like Flatpickr.
-- [ ] Replace custom table actions with modern Vanilla JS or native DataTables features.
-- [ ] Migrate from SimpleTest to PHPUnit for better testing capabilities.
+For the detailed, actionable modernization and maintenance plan, see [ROADMAP.md](ROADMAP.md). The roadmap follows a bottom-to-top execution strategy and is the definitive source for current project priorities.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,37 @@
+# ROADMAP
+
+This document outlines the planned improvements and modernization steps for the PHP Address Book project.
+
+## Roadmap Rules
+- **Management**: This roadmap is managed by the `Jules Automation` workflow.
+- **Execution Order**: Tasks are executed from **bottom to top**.
+- **New Tasks**: New tasks are added to the **top** of the list.
+- **Task Granularity**: Focus on modest, feasible, and reasonable steps. Larger goals should be broken down into smaller tasks.
+- **Completion**: Tasks are marked as completed with a timestamp when finished.
+
+---
+
+## Open Tasks
+
+- [ ] **Fix `deprecated` column filtering logic**: The application filters using `WHERE deprecated IS NULL`, but the schema defines it as `NOT NULL DEFAULT '1000-01-01 00:00:00'`.
+- [ ] **Modernize Table Sorting**: Replace the legacy `js/tablesort.min.js` with native DataTables sorting capabilities.
+- [ ] **Modernize Identicon Generation**: Replace the local `lib/identicon.php` with a modern library like `bit-wasp/identicon`.
+- [ ] **Modernize Translation Engine**: Replace legacy **PHP-gettext 1.0** with native PHP gettext or Symfony Translation.
+- [ ] **Upgrade parseCSV**: Update `lib/parsecsv.lib.php` from 0.4.3 beta to the active fork version 1.3.x.
+
+### Phase 3: Technical Debt Cleanup
+- [ ] **Migrate Testing Framework**: Transition from SimpleTest to **PHPUnit** for more robust testing and PHP 8.x compatibility.
+- [ ] **Modernize Table Actions**: Replace custom `js/tableActions.min.js` with modern Vanilla JS or DataTables features.
+- [ ] **Remove MooTools**: Completely remove MooTools 1.11 and migrate `jscalendar` to a modern, lightweight date picker like **Flatpickr**.
+
+### Phase 2: Core Improvements
+- [ ] **Database Layer Refactor**: Transition from the `mysql_shim.php` compatibility layer to native `mysqli` or a modern ORM/Query Builder.
+- [ ] **Responsive UI**: Implement a mobile-first responsive design using modern CSS (Flexbox/Grid).
+- [ ] **PHP 8.x Native Support**: Resolve all remaining incompatibilities in the core logic and testing framework to ensure full PHP 8.x stability.
+
+### Phase 1: Dependency Modernization
+- [ ] Upgrade **Z-Push** from 2.2.12 to 2.7.x.
+- [ ] Upgrade **HybridAuth** from 2.1.0 to 3.x.
+- [ ] Replace **PHP Excel Reader 2.21** with **PhpSpreadsheet**.
+- [ ] Upgrade **DataTables** from 1.9.4 to 2.x.
+- [ ] Upgrade **jQuery** from 1.8.2 to 3.7.x.


### PR DESCRIPTION
This PR introduces a dedicated `ROADMAP.md` file to the project to consolidate all open problems, technical debts, and modernization tasks in one place. 

Key changes:
- **New `ROADMAP.md`**: Includes a structured list of tasks categorized by modernization phases (Dependency Modernization, Core Improvements, Technical Debt Cleanup) and general open tasks. It also defines clear rules for roadmap management, such as the "bottom-to-top" execution order.
- **Updated `CONCEPT.md`**: Removed the redundant roadmap section and added a reference to the new `ROADMAP.md` to ensure a single source of truth for project priorities.

The tasks consolidated into the roadmap include:
- Library upgrades (jQuery, DataTables, PhpSpreadsheet, etc.)
- Core improvements (PHP 8.x support, Responsive UI, Database layer refactor)
- Technical debt cleanup (Migrating to PHPUnit, removing MooTools)
- Identified bugs (e.g., the `deprecated` column filtering logic)

Fixes #54

---
*PR created automatically by Jules for task [17301465129212182009](https://jules.google.com/task/17301465129212182009) started by @chatelao*