### PR TITLE
Patch SimpleTest core for PHP 8.x compatibility

### DIFF
--- a/MIGRATION_ROADMAP.md
+++ b/MIGRATION_ROADMAP.md
@@ -20,7 +20,7 @@ This document outlines the detailed, granular steps for modernizing and migratin
 ### Phase 2: Core Improvements
 - [ ] **PHP 8.x Native Support**
     - [x] **Harden `mysql_shim.php`**: (Completed: 2025-05-22) Added explicit `instanceof` checks for all parameters passed to `mysqli_*` functions to prevent `TypeError`.
-    - [ ] **Patch SimpleTest**: Identify and fix all occurrences in `test/simpletest/` where `count()` is called on null or non-countable types, ensuring the test suite can run on PHP 8.x.
+    - [x] **Patch SimpleTest core for PHP 8.x**: (Completed: 2026-04-27) Added `SimpleTestCompatibility::count()` and updated all call sites in `test/simpletest/` to handle non-countable types. Also hardened `socket.php` against `fclose()` TypeErrors.
     - [ ] **Resolve session warnings**: Address `session_start()` and other session-related warnings that became more strict in PHP 8.x.
 - [ ] **Responsive UI**: Implement a mobile-first responsive design using modern CSS (Flexbox/Grid).
 - [ ] **Database Layer Refactor**

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -26,7 +26,7 @@ This document outlines the planned improvements and modernization steps for the 
 ### Phase 2: Core Improvements
 - [ ] **Database Layer Refactor**: Transition from the `mysql_shim.php` compatibility layer to native `mysqli` or a modern ORM/Query Builder.
 - [ ] **Responsive UI**: Implement a mobile-first responsive design using modern CSS (Flexbox/Grid).
-- [ ] **PHP 8.x Native Support**: (Partially Completed: 2025-05-22) Hardened `mysql_shim.php` against `TypeError`. Resolve all remaining incompatibilities in the core logic and testing framework to ensure full PHP 8.x stability.
+- [ ] **PHP 8.x Native Support**: (Partially Completed: 2026-04-27) Hardened `mysql_shim.php` (2025) and patched SimpleTest core (2026) to handle PHP 8.x `count()` and `fclose()` changes. Further work needed on legacy libraries like PHP-gettext.
 
 ### Phase 1: Dependency Modernization
 - [ ] Upgrade **Z-Push** from 2.2.12 to 2.7.x.

--- a/test/simpletest/arguments.php
+++ b/test/simpletest/arguments.php
@@ -27,7 +27,7 @@ class SimpleArguments {
      */
     function __construct($arguments) {
         array_shift($arguments);
-        while (count($arguments) > 0) {
+        while (SimpleTestCompatibility::count($arguments) > 0) {
             list($key, $value) = $this->parseArgument($arguments);
             $this->assign($key, $value);
         }
@@ -169,7 +169,7 @@ class SimpleHelp {
     function render() {
         $tab_stop = $this->longestFlag($this->flag_sets) + 4;
         $text = $this->overview . "\n";
-        for ($i = 0; $i < count($this->flag_sets); $i++) {
+        for ($i = 0; $i < SimpleTestCompatibility::count($this->flag_sets); $i++) {
             $text .= $this->renderFlagSet($this->flag_sets[$i], $this->explanations[$i], $tab_stop);
         }
         return $this->noDuplicateNewLines($text);

--- a/test/simpletest/authentication.php
+++ b/test/simpletest/authentication.php
@@ -55,7 +55,7 @@ class SimpleRealm {
     protected function getCommonPath($first, $second) {
         $first = explode('/', $first);
         $second = explode('/', $second);
-        for ($i = 0; $i < min(count($first), count($second)); $i++) {
+        for ($i = 0; $i < min(SimpleTestCompatibility::count($first), SimpleTestCompatibility::count($second)); $i++) {
             if ($first[$i] != $second[$i]) {
                 return implode('/', array_slice($first, 0, $i)) . '/';
             }

--- a/test/simpletest/browser.php
+++ b/test/simpletest/browser.php
@@ -61,7 +61,7 @@ class SimpleBrowserHistory {
      *    @access private
      */
     protected function atEnd() {
-        return ($this->position + 1 >= count($this->sequence)) && ! $this->isEmpty();
+        return ($this->position + 1 >= SimpleTestCompatibility::count($this->sequence)) && ! $this->isEmpty();
     }
 
     /**
@@ -562,7 +562,7 @@ class SimpleBrowser {
      */
     function retry() {
         $frames = $this->page->getFrameFocus();
-        if (count($frames) > 0) {
+        if (SimpleTestCompatibility::count($frames) > 0) {
             $this->loadFrame(
                     $frames,
                     $this->page->getUrl(),
@@ -1061,10 +1061,10 @@ class SimpleBrowser {
      */
     function getLink($label, $index = 0) {
         $urls = $this->page->getUrlsByLabel($label);
-        if (count($urls) == 0) {
+        if (SimpleTestCompatibility::count($urls) == 0) {
             return false;
         }
-        if (count($urls) < $index + 1) {
+        if (SimpleTestCompatibility::count($urls) < $index + 1) {
             return false;
         }
         return $urls[$index];

--- a/test/simpletest/compatibility.php
+++ b/test/simpletest/compatibility.php
@@ -162,5 +162,18 @@ class SimpleTestCompatibility {
             set_socket_timeout($handle, $timeout, 0);
         }
     }
+
+    /**
+     *    Count elements of an object or array.
+     *    @param mixed $value    Array or countable object.
+     *    @return integer        Number of elements.
+     *    @access public
+     */
+    static function count($value) {
+        if (is_array($value) || $value instanceof Countable) {
+            return count($value);
+        }
+        return 0;
+    }
 }
 ?>

--- a/test/simpletest/cookies.php
+++ b/test/simpletest/cookies.php
@@ -244,7 +244,7 @@ class SimpleCookieJar {
      */
     function restartSession($date = false) {
         $surviving_cookies = array();
-        for ($i = 0; $i < count($this->cookies); $i++) {
+        for ($i = 0; $i < SimpleTestCompatibility::count($this->cookies); $i++) {
             if (! $this->cookies[$i]->getValue()) {
                 continue;
             }
@@ -268,7 +268,7 @@ class SimpleCookieJar {
      *    @access public
      */
     function agePrematurely($interval) {
-        for ($i = 0; $i < count($this->cookies); $i++) {
+        for ($i = 0; $i < SimpleTestCompatibility::count($this->cookies); $i++) {
             $this->cookies[$i]->agePrematurely($interval);
         }
     }
@@ -299,7 +299,7 @@ class SimpleCookieJar {
      *    @access private
      */
     protected function findFirstMatch($cookie) {
-        for ($i = 0; $i < count($this->cookies); $i++) {
+        for ($i = 0; $i < SimpleTestCompatibility::count($this->cookies); $i++) {
             $is_match = $this->isMatch(
                     $cookie,
                     $this->cookies[$i]->getHost(),
@@ -309,7 +309,7 @@ class SimpleCookieJar {
                 return $i;
             }
         }
-        return count($this->cookies);
+        return SimpleTestCompatibility::count($this->cookies);
     }
 
     /**

--- a/test/simpletest/dumper.php
+++ b/test/simpletest/dumper.php
@@ -33,7 +33,7 @@ class SimpleDumper {
             case "Boolean":
                 return "Boolean: " . ($value ? "true" : "false");
             case "Array":
-                return "Array: " . count($value) . " items";
+                return "Array: " . SimpleTestCompatibility::count($value) . " items";
             case "Object":
                 return "Object: of " . get_class($value);
             case "String":

--- a/test/simpletest/encoding.php
+++ b/test/simpletest/encoding.php
@@ -285,9 +285,9 @@ class SimpleEncoding {
                 $values[] = $pair->getValue();
             }
         }
-        if (count($values) == 0) {
+        if (SimpleTestCompatibility::count($values) == 0) {
             return false;
-        } elseif (count($values) == 1) {
+        } elseif (SimpleTestCompatibility::count($values) == 1) {
             return $values[0];
         } else {
             return $values;

--- a/test/simpletest/errors.php
+++ b/test/simpletest/errors.php
@@ -168,7 +168,7 @@ class SimpleErrorQueue {
      *    @access public
      */
     function extract() {
-        if (count($this->queue)) {
+        if (SimpleTestCompatibility::count($this->queue)) {
             return array_shift($this->queue);
         }
         return false;
@@ -180,7 +180,7 @@ class SimpleErrorQueue {
      *    @access private
      */
     protected function extractExpectation() {
-        if (count($this->expectation_queue)) {
+        if (SimpleTestCompatibility::count($this->expectation_queue)) {
             return array_shift($this->expectation_queue);
         }
         return false;

--- a/test/simpletest/form.php
+++ b/test/simpletest/form.php
@@ -122,7 +122,7 @@ class SimpleForm {
     protected function encode() {
         $class = $this->encoding;
         $encoding = new $class();
-        for ($i = 0, $count = count($this->widgets); $i < $count; $i++) {
+        for ($i = 0, $count = SimpleTestCompatibility::count($this->widgets); $i < $count; $i++) {
             $this->widgets[$i]->write($encoding);
         }
         return $encoding;
@@ -175,7 +175,7 @@ class SimpleForm {
     protected function addRadioButton($tag) {
         if (! isset($this->radios[$tag->getName()])) {
             $this->widgets[] = new SimpleRadioGroup();
-            $this->radios[$tag->getName()] = count($this->widgets) - 1;
+            $this->radios[$tag->getName()] = SimpleTestCompatibility::count($this->widgets) - 1;
         }
         $this->widgets[$this->radios[$tag->getName()]]->addWidget($tag);
     }
@@ -188,7 +188,7 @@ class SimpleForm {
     protected function addCheckbox($tag) {
         if (! isset($this->checkboxes[$tag->getName()])) {
             $this->widgets[] = $tag;
-            $this->checkboxes[$tag->getName()] = count($this->widgets) - 1;
+            $this->checkboxes[$tag->getName()] = SimpleTestCompatibility::count($this->widgets) - 1;
         } else {
             $index = $this->checkboxes[$tag->getName()];
             if (! SimpleTestCompatibility::isA($this->widgets[$index], 'SimpleCheckboxGroup')) {
@@ -208,7 +208,7 @@ class SimpleForm {
      *    @access public
      */
     function getValue($selector) {
-        for ($i = 0, $count = count($this->widgets); $i < $count; $i++) {
+        for ($i = 0, $count = SimpleTestCompatibility::count($this->widgets); $i < $count; $i++) {
             if ($selector->isMatch($this->widgets[$i])) {
                 return $this->widgets[$i]->getValue();
             }
@@ -233,7 +233,7 @@ class SimpleForm {
     function setField($selector, $value, $position=false) {
         $success = false;
         $_position = 0;
-        for ($i = 0, $count = count($this->widgets); $i < $count; $i++) {
+        for ($i = 0, $count = SimpleTestCompatibility::count($this->widgets); $i < $count; $i++) {
             if ($selector->isMatch($this->widgets[$i])) {
                 $_position++;
                 if ($position === false or $_position === (int)$position) {
@@ -253,7 +253,7 @@ class SimpleForm {
      *    @access public
      */
     function attachLabelBySelector($selector, $label) {
-        for ($i = 0, $count = count($this->widgets); $i < $count; $i++) {
+        for ($i = 0, $count = SimpleTestCompatibility::count($this->widgets); $i < $count; $i++) {
             if ($selector->isMatch($this->widgets[$i])) {
                 if (method_exists($this->widgets[$i], 'setLabel')) {
                     $this->widgets[$i]->setLabel($label);

--- a/test/simpletest/frames.php
+++ b/test/simpletest/frames.php
@@ -48,7 +48,7 @@ class SimpleFrameset {
     function addFrame($page, $name = false) {
         $this->frames[] = $page;
         if ($name) {
-            $this->names[$name] = count($this->frames) - 1;
+            $this->names[$name] = SimpleTestCompatibility::count($this->frames) - 1;
         }
     }
 
@@ -67,7 +67,7 @@ class SimpleFrameset {
         } else {
             $index = $name - 1;
         }
-        if (count($path) == 0) {
+        if (SimpleTestCompatibility::count($path) == 0) {
             $this->frames[$index] = &$page;
             return;
         }
@@ -121,7 +121,7 @@ class SimpleFrameset {
                 return $this->frames[$this->focus]->setFrameFocusByIndex($choice);
             }
         }
-        if (($choice < 1) || ($choice > count($this->frames))) {
+        if (($choice < 1) || ($choice > SimpleTestCompatibility::count($this->frames))) {
             return false;
         }
         $this->focus = $choice - 1;
@@ -163,7 +163,7 @@ class SimpleFrameset {
      *    @access private
      */
     protected function clearNestedFramesFocus() {
-        for ($i = 0; $i < count($this->frames); $i++) {
+        for ($i = 0; $i < SimpleTestCompatibility::count($this->frames); $i++) {
             $this->frames[$i]->clearFrameFocus();
         }
     }
@@ -186,7 +186,7 @@ class SimpleFrameset {
      */
     function getFrames() {
         $report = array();
-        for ($i = 0; $i < count($this->frames); $i++) {
+        for ($i = 0; $i < SimpleTestCompatibility::count($this->frames); $i++) {
             $report[$this->getPublicNameFromIndex($i)] =
                     $this->frames[$i]->getFrames();
         }
@@ -204,7 +204,7 @@ class SimpleFrameset {
             return $this->frames[$this->focus]->getRaw();
         }
         $raw = '';
-        for ($i = 0; $i < count($this->frames); $i++) {
+        for ($i = 0; $i < SimpleTestCompatibility::count($this->frames); $i++) {
             $raw .= $this->frames[$i]->getRaw();
         }
         return $raw;
@@ -221,7 +221,7 @@ class SimpleFrameset {
             return $this->frames[$this->focus]->getText();
         }
         $raw = '';
-        for ($i = 0; $i < count($this->frames); $i++) {
+        for ($i = 0; $i < SimpleTestCompatibility::count($this->frames); $i++) {
             $raw .= ' ' . $this->frames[$i]->getText();
         }
         return trim($raw);
@@ -521,7 +521,7 @@ class SimpleFrameset {
                     $method,
                     $attribute);
         }
-        for ($i = 0; $i < count($this->frames); $i++) {
+        for ($i = 0; $i < SimpleTestCompatibility::count($this->frames); $i++) {
             $form = $this->findFormInFrame(
                     $this->frames[$i],
                     $i,
@@ -565,7 +565,7 @@ class SimpleFrameset {
         if (is_integer($this->focus)) {
             $this->frames[$this->focus]->setField($selector, $value);
         } else {
-            for ($i = 0; $i < count($this->frames); $i++) {
+            for ($i = 0; $i < SimpleTestCompatibility::count($this->frames); $i++) {
                 $this->frames[$i]->setField($selector, $value);
             }
         }
@@ -580,7 +580,7 @@ class SimpleFrameset {
      *    @access public
      */
     function getField($selector) {
-        for ($i = 0; $i < count($this->frames); $i++) {
+        for ($i = 0; $i < SimpleTestCompatibility::count($this->frames); $i++) {
             $value = $this->frames[$i]->getField($selector);
             if (isset($value)) {
                 return $value;

--- a/test/simpletest/http.php
+++ b/test/simpletest/http.php
@@ -244,7 +244,7 @@ class SimpleHttpRequest {
         foreach ($this->headers as $header_line) {
             $socket->write($header_line . "\r\n");
         }
-        if (count($this->cookies) > 0) {
+        if (SimpleTestCompatibility::count($this->cookies) > 0) {
             $socket->write("Cookie: " . implode(";", $this->cookies) . "\r\n");
         }
         $encoding->writeHeadersTo($socket);

--- a/test/simpletest/mock_objects.php
+++ b/test/simpletest/mock_objects.php
@@ -52,10 +52,10 @@ class ParametersExpectation extends SimpleExpectation {
         if (! is_array($this->expected)) {
             return true;
         }
-        if (count($this->expected) != count($parameters)) {
+        if (SimpleTestCompatibility::count($this->expected) != SimpleTestCompatibility::count($parameters)) {
             return false;
         }
-        for ($i = 0; $i < count($this->expected); $i++) {
+        for ($i = 0; $i < SimpleTestCompatibility::count($this->expected); $i++) {
             if (! $this->testParameter($parameters[$i], $this->expected[$i])) {
                 return false;
             }
@@ -83,7 +83,7 @@ class ParametersExpectation extends SimpleExpectation {
      */
     function testMessage($parameters) {
         if ($this->test($parameters)) {
-            return "Expectation of " . count($this->expected) .
+            return "Expectation of " . SimpleTestCompatibility::count($this->expected) .
                     " arguments of [" . $this->renderArguments($this->expected) .
                     "] is correct";
         } else {
@@ -99,14 +99,14 @@ class ParametersExpectation extends SimpleExpectation {
      *    @return string              Description of difference.
      */
     protected function describeDifference($expected, $parameters) {
-        if (count($expected) != count($parameters)) {
-            return "Expected " . count($expected) .
+        if (SimpleTestCompatibility::count($expected) != SimpleTestCompatibility::count($parameters)) {
+            return "Expected " . SimpleTestCompatibility::count($expected) .
                     " arguments of [" . $this->renderArguments($expected) .
-                    "] but got " . count($parameters) .
+                    "] but got " . SimpleTestCompatibility::count($parameters) .
                     " arguments of [" . $this->renderArguments($parameters) . "]";
         }
         $messages = array();
-        for ($i = 0; $i < count($expected); $i++) {
+        for ($i = 0; $i < SimpleTestCompatibility::count($expected); $i++) {
             $comparison = $this->coerceToExpectation($expected[$i]);
             if (! $comparison->test($parameters[$i])) {
                 $messages[] = "parameter " . ($i + 1) . " with [" .
@@ -299,7 +299,7 @@ class SimpleSignatureMap {
      *    @param mixed $action        Reference placed in the map.
      */
     function add($parameters, $action) {
-        $place = count($this->map);
+        $place = SimpleTestCompatibility::count($this->map);
         $this->map[$place] = array();
         $this->map[$place]['params'] = new ParametersExpectation($parameters);
         $this->map[$place]['content'] = $action;
@@ -351,7 +351,7 @@ class SimpleSignatureMap {
      *    @return array               Reference to slot or null.
      */
     function &findFirstSlot($parameters) {
-        $count = count($this->map);
+        $count = SimpleTestCompatibility::count($this->map);
         for ($i = 0; $i < $count; $i++) {
             if ($this->map[$i]["params"]->test($parameters)) {
                 return $this->map[$i];
@@ -477,7 +477,7 @@ class SimpleCallSchedule {
         if ($args === false) {
             return false;
         }
-        for ($i = 0; $i < count($args); $i++) {
+        for ($i = 0; $i < SimpleTestCompatibility::count($args); $i++) {
             if ($args[$i] === $this->wildcard) {
                 $args[$i] = new AnythingExpectation();
             }
@@ -717,7 +717,7 @@ class SimpleMock {
         if ($args === false) {
             return false;
         }
-        for ($i = 0; $i < count($args); $i++) {
+        for ($i = 0; $i < SimpleTestCompatibility::count($args); $i++) {
             if ($args[$i] === $this->wildcard) {
                 $args[$i] = new AnythingExpectation();
             }
@@ -1347,7 +1347,7 @@ class MockGenerator {
         if (function_exists('spl_classes')) {
             $interfaces = array_diff($interfaces, array('Traversable'));
         }
-        if (count($interfaces) > 0) {
+        if (SimpleTestCompatibility::count($interfaces) > 0) {
             $implements = 'implements ' . implode(', ', $interfaces);
         }
         $code = "class " . $this->mock_class . " extends " . $this->mock_base . " $implements {\n";

--- a/test/simpletest/page.php
+++ b/test/simpletest/page.php
@@ -295,7 +295,7 @@ class SimplePage {
      *    @access public
      */
     function hasFrames() {
-        return count($this->frames) > 0;
+        return SimpleTestCompatibility::count($this->frames) > 0;
     }
 
     /**
@@ -312,7 +312,7 @@ class SimplePage {
             return false;
         }
         $urls = array();
-        for ($i = 0; $i < count($this->frames); $i++) {
+        for ($i = 0; $i < SimpleTestCompatibility::count($this->frames); $i++) {
             $name = $this->frames[$i]->getAttribute('name');
             $url = new SimpleUrl($this->frames[$i]->getAttribute('src'));
             $urls[$name ? $name : $i + 1] = $this->expandUrl($url);
@@ -443,7 +443,7 @@ class SimplePage {
      *    @access public
      */
     function getFormBySubmit($selector) {
-        for ($i = 0; $i < count($this->forms); $i++) {
+        for ($i = 0; $i < SimpleTestCompatibility::count($this->forms); $i++) {
             if ($this->forms[$i]->hasSubmit($selector)) {
                 return $this->forms[$i];
             }
@@ -460,7 +460,7 @@ class SimplePage {
      *    @access public
      */
     function getFormByImage($selector) {
-        for ($i = 0; $i < count($this->forms); $i++) {
+        for ($i = 0; $i < SimpleTestCompatibility::count($this->forms); $i++) {
             if ($this->forms[$i]->hasImage($selector)) {
                 return $this->forms[$i];
             }
@@ -477,7 +477,7 @@ class SimplePage {
      *    @access public
      */
     function getFormById($id) {
-        for ($i = 0; $i < count($this->forms); $i++) {
+        for ($i = 0; $i < SimpleTestCompatibility::count($this->forms); $i++) {
             if ($this->forms[$i]->getId() == $id) {
                 return $this->forms[$i];
             }
@@ -495,7 +495,7 @@ class SimplePage {
      */
     function setField($selector, $value, $position=false) {
         $is_set = false;
-        for ($i = 0; $i < count($this->forms); $i++) {
+        for ($i = 0; $i < SimpleTestCompatibility::count($this->forms); $i++) {
             if ($this->forms[$i]->setField($selector, $value, $position)) {
                 $is_set = true;
             }
@@ -512,7 +512,7 @@ class SimplePage {
      *    @access public
      */
     function getField($selector) {
-        for ($i = 0; $i < count($this->forms); $i++) {
+        for ($i = 0; $i < SimpleTestCompatibility::count($this->forms); $i++) {
             $value = $this->forms[$i]->getValue($selector);
             if (isset($value)) {
                 return $value;

--- a/test/simpletest/php_parser.php
+++ b/test/simpletest/php_parser.php
@@ -53,7 +53,7 @@ class ParallelRegex {
      *    @access public
      */
     function addPattern($pattern, $label = true) {
-        $count = count($this->patterns);
+        $count = SimpleTestCompatibility::count($this->patterns);
         $this->patterns[$count] = $pattern;
         $this->labels[$count] = $label;
         $this->regex = null;
@@ -69,7 +69,7 @@ class ParallelRegex {
      *    @access public
      */
     function match($subject, &$match) {
-        if (count($this->patterns) == 0) {
+        if (SimpleTestCompatibility::count($this->patterns) == 0) {
             return false;
         }
         if (! preg_match($this->getCompoundedRegex(), $subject, $matches)) {
@@ -77,7 +77,7 @@ class ParallelRegex {
             return false;
         }
         $match = $matches[0];
-        for ($i = 1; $i < count($matches); $i++) {
+        for ($i = 1; $i < SimpleTestCompatibility::count($matches); $i++) {
             if ($matches[$i]) {
                 return $this->labels[$i - 1];
             }
@@ -95,7 +95,7 @@ class ParallelRegex {
      */
     protected function getCompoundedRegex() {
         if ($this->regex == null) {
-            for ($i = 0, $count = count($this->patterns); $i < $count; $i++) {
+            for ($i = 0, $count = SimpleTestCompatibility::count($this->patterns); $i < $count; $i++) {
                 $this->patterns[$i] = '(' . str_replace(
                         array('/', '(', ')'),
                         array('\/', '\(', '\)'),
@@ -139,7 +139,7 @@ class SimpleStateStack {
      *    @access public
      */
     function getCurrent() {
-        return $this->stack[count($this->stack) - 1];
+        return $this->stack[SimpleTestCompatibility::count($this->stack) - 1];
     }
 
     /**
@@ -160,7 +160,7 @@ class SimpleStateStack {
      *    @access public
      */
     function leave() {
-        if (count($this->stack) == 1) {
+        if (SimpleTestCompatibility::count($this->stack) == 1) {
             return false;
         }
         array_pop($this->stack);
@@ -843,7 +843,7 @@ class SimplePhpPageBuilder {
      *    @access private
      */
     protected function hasNamedTagOnOpenTagStack($name) {
-        return isset($this->tags[$name]) && (count($this->tags[$name]) > 0);
+        return isset($this->tags[$name]) && (SimpleTestCompatibility::count($this->tags[$name]) > 0);
     }
 
     /**
@@ -870,7 +870,7 @@ class SimplePhpPageBuilder {
      */
     protected function addContentToAllOpenTags($text) {
         foreach (array_keys($this->tags) as $name) {
-            for ($i = 0, $count = count($this->tags[$name]); $i < $count; $i++) {
+            for ($i = 0, $count = SimpleTestCompatibility::count($this->tags[$name]); $i < $count; $i++) {
                 $this->tags[$name][$i]->addContent($text);
             }
         }
@@ -888,7 +888,7 @@ class SimplePhpPageBuilder {
             return;
         }
         foreach (array_keys($this->tags) as $name) {
-            for ($i = 0, $count = count($this->tags[$name]); $i < $count; $i++) {
+            for ($i = 0, $count = SimpleTestCompatibility::count($this->tags[$name]); $i < $count; $i++) {
                 $this->tags[$name][$i]->addTag($tag);
             }
         }
@@ -921,7 +921,7 @@ class SimplePhpPageBuilder {
         } elseif ($tag->getTagName() == "title") {
             $this->page->setTitle($tag);
         } elseif ($this->isFormElement($tag->getTagName())) {
-            for ($i = 0; $i < count($this->open_forms); $i++) {
+            for ($i = 0; $i < SimpleTestCompatibility::count($this->open_forms); $i++) {
                 $this->open_forms[$i]->addWidget($tag);
             }
             $this->last_widget = $tag;
@@ -979,7 +979,7 @@ class SimplePhpPageBuilder {
      *    @access public
      */
     protected function acceptFormEnd() {
-        if (count($this->open_forms)) {
+        if (SimpleTestCompatibility::count($this->open_forms)) {
             $this->complete_forms[] = array_pop($this->open_forms);
         }
     }
@@ -1037,11 +1037,11 @@ class SimplePhpPageBuilder {
      *    @access public
      */
     protected function acceptPageEnd() {
-        while (count($this->open_forms)) {
+        while (SimpleTestCompatibility::count($this->open_forms)) {
             $this->complete_forms[] = array_pop($this->open_forms);
         }
         foreach ($this->left_over_labels as $label) {
-            for ($i = 0, $count = count($this->complete_forms); $i < $count; $i++) {
+            for ($i = 0, $count = SimpleTestCompatibility::count($this->complete_forms); $i < $count; $i++) {
                 $this->complete_forms[$i]->attachLabelBySelector(
                         new SimpleById($label->getFor()),
                         $label->getText());

--- a/test/simpletest/scorer.php
+++ b/test/simpletest/scorer.php
@@ -276,7 +276,7 @@ class SimpleReporter extends SimpleScorer {
         if (! isset($this->size)) {
             $this->size = $size;
         }
-        if (count($this->test_stack) == 0) {
+        if (SimpleTestCompatibility::count($this->test_stack) == 0) {
             $this->paintHeader($test_name);
         }
         $this->test_stack[] = $test_name;
@@ -291,7 +291,7 @@ class SimpleReporter extends SimpleScorer {
      */
     function paintGroupEnd($test_name) {
         array_pop($this->test_stack);
-        if (count($this->test_stack) == 0) {
+        if (SimpleTestCompatibility::count($this->test_stack) == 0) {
             $this->paintFooter($test_name);
         }
     }
@@ -308,7 +308,7 @@ class SimpleReporter extends SimpleScorer {
         if (! isset($this->size)) {
             $this->size = 1;
         }
-        if (count($this->test_stack) == 0) {
+        if (SimpleTestCompatibility::count($this->test_stack) == 0) {
             $this->paintHeader($test_name);
         }
         $this->test_stack[] = $test_name;
@@ -323,7 +323,7 @@ class SimpleReporter extends SimpleScorer {
     function paintCaseEnd($test_name) {
         $this->progress++;
         array_pop($this->test_stack);
-        if (count($this->test_stack) == 0) {
+        if (SimpleTestCompatibility::count($this->test_stack) == 0) {
             $this->paintFooter($test_name);
         }
     }
@@ -651,7 +651,7 @@ class MultipleReporter {
      *    @access public
      */
     function makeDry($is_dry = true) {
-        for ($i = 0; $i < count($this->reporters); $i++) {
+        for ($i = 0; $i < SimpleTestCompatibility::count($this->reporters); $i++) {
             $this->reporters[$i]->makeDry($is_dry);
         }
     }
@@ -665,7 +665,7 @@ class MultipleReporter {
      *    @access public
      */
     function getStatus() {
-        for ($i = 0; $i < count($this->reporters); $i++) {
+        for ($i = 0; $i < SimpleTestCompatibility::count($this->reporters); $i++) {
             if (! $this->reporters[$i]->getStatus()) {
                 return false;
             }
@@ -681,7 +681,7 @@ class MultipleReporter {
      *    @access public
      */
     function shouldInvoke($test_case_name, $method) {
-        for ($i = 0; $i < count($this->reporters); $i++) {
+        for ($i = 0; $i < SimpleTestCompatibility::count($this->reporters); $i++) {
             if (! $this->reporters[$i]->shouldInvoke($test_case_name, $method)) {
                 return false;
             }
@@ -696,7 +696,7 @@ class MultipleReporter {
      *    @access public
      */
     function createInvoker($invoker) {
-        for ($i = 0; $i < count($this->reporters); $i++) {
+        for ($i = 0; $i < SimpleTestCompatibility::count($this->reporters); $i++) {
             $invoker = $this->reporters[$i]->createInvoker($invoker);
         }
         return $invoker;
@@ -719,7 +719,7 @@ class MultipleReporter {
      *    @access public
      */
     function paintGroupStart($test_name, $size) {
-        for ($i = 0; $i < count($this->reporters); $i++) {
+        for ($i = 0; $i < SimpleTestCompatibility::count($this->reporters); $i++) {
             $this->reporters[$i]->paintGroupStart($test_name, $size);
         }
     }
@@ -730,7 +730,7 @@ class MultipleReporter {
      *    @access public
      */
     function paintGroupEnd($test_name) {
-        for ($i = 0; $i < count($this->reporters); $i++) {
+        for ($i = 0; $i < SimpleTestCompatibility::count($this->reporters); $i++) {
             $this->reporters[$i]->paintGroupEnd($test_name);
         }
     }
@@ -741,7 +741,7 @@ class MultipleReporter {
      *    @access public
      */
     function paintCaseStart($test_name) {
-        for ($i = 0; $i < count($this->reporters); $i++) {
+        for ($i = 0; $i < SimpleTestCompatibility::count($this->reporters); $i++) {
             $this->reporters[$i]->paintCaseStart($test_name);
         }
     }
@@ -752,7 +752,7 @@ class MultipleReporter {
      *    @access public
      */
     function paintCaseEnd($test_name) {
-        for ($i = 0; $i < count($this->reporters); $i++) {
+        for ($i = 0; $i < SimpleTestCompatibility::count($this->reporters); $i++) {
             $this->reporters[$i]->paintCaseEnd($test_name);
         }
     }
@@ -763,7 +763,7 @@ class MultipleReporter {
      *    @access public
      */
     function paintMethodStart($test_name) {
-        for ($i = 0; $i < count($this->reporters); $i++) {
+        for ($i = 0; $i < SimpleTestCompatibility::count($this->reporters); $i++) {
             $this->reporters[$i]->paintMethodStart($test_name);
         }
     }
@@ -774,7 +774,7 @@ class MultipleReporter {
      *    @access public
      */
     function paintMethodEnd($test_name) {
-        for ($i = 0; $i < count($this->reporters); $i++) {
+        for ($i = 0; $i < SimpleTestCompatibility::count($this->reporters); $i++) {
             $this->reporters[$i]->paintMethodEnd($test_name);
         }
     }
@@ -785,7 +785,7 @@ class MultipleReporter {
      *    @access public
      */
     function paintPass($message) {
-        for ($i = 0; $i < count($this->reporters); $i++) {
+        for ($i = 0; $i < SimpleTestCompatibility::count($this->reporters); $i++) {
             $this->reporters[$i]->paintPass($message);
         }
     }
@@ -796,7 +796,7 @@ class MultipleReporter {
      *    @access public
      */
     function paintFail($message) {
-        for ($i = 0; $i < count($this->reporters); $i++) {
+        for ($i = 0; $i < SimpleTestCompatibility::count($this->reporters); $i++) {
             $this->reporters[$i]->paintFail($message);
         }
     }
@@ -808,7 +808,7 @@ class MultipleReporter {
      *    @access public
      */
     function paintError($message) {
-        for ($i = 0; $i < count($this->reporters); $i++) {
+        for ($i = 0; $i < SimpleTestCompatibility::count($this->reporters); $i++) {
             $this->reporters[$i]->paintError($message);
         }
     }
@@ -819,7 +819,7 @@ class MultipleReporter {
      *    @access public
      */
     function paintException($exception) {
-        for ($i = 0; $i < count($this->reporters); $i++) {
+        for ($i = 0; $i < SimpleTestCompatibility::count($this->reporters); $i++) {
             $this->reporters[$i]->paintException($exception);
         }
     }
@@ -830,7 +830,7 @@ class MultipleReporter {
      *    @access public
      */
     function paintSkip($message) {
-        for ($i = 0; $i < count($this->reporters); $i++) {
+        for ($i = 0; $i < SimpleTestCompatibility::count($this->reporters); $i++) {
             $this->reporters[$i]->paintSkip($message);
         }
     }
@@ -841,7 +841,7 @@ class MultipleReporter {
      *    @access public
      */
     function paintMessage($message) {
-        for ($i = 0; $i < count($this->reporters); $i++) {
+        for ($i = 0; $i < SimpleTestCompatibility::count($this->reporters); $i++) {
             $this->reporters[$i]->paintMessage($message);
         }
     }
@@ -852,7 +852,7 @@ class MultipleReporter {
      *    @access public
      */
     function paintFormattedMessage($message) {
-        for ($i = 0; $i < count($this->reporters); $i++) {
+        for ($i = 0; $i < SimpleTestCompatibility::count($this->reporters); $i++) {
             $this->reporters[$i]->paintFormattedMessage($message);
         }
     }
@@ -867,7 +867,7 @@ class MultipleReporter {
      *    @access public
      */
     function paintSignal($type, $payload) {
-        for ($i = 0; $i < count($this->reporters); $i++) {
+        for ($i = 0; $i < SimpleTestCompatibility::count($this->reporters); $i++) {
             $this->reporters[$i]->paintSignal($type, $payload);
         }
     }

--- a/test/simpletest/simpletest.php
+++ b/test/simpletest/simpletest.php
@@ -91,7 +91,7 @@ class SimpleTest {
             $classes = array($classes);
         }
         $registry = &SimpleTest::getRegistry();
-        for ($i = count($registry['Preferred']) - 1; $i >= 0; $i--) {
+        for ($i = SimpleTestCompatibility::count($registry['Preferred']) - 1; $i >= 0; $i--) {
             foreach ($classes as $class) {
                 if (SimpleTestCompatibility::isA($registry['Preferred'][$i], $class)) {
                     return $registry['Preferred'][$i];

--- a/test/simpletest/socket.php
+++ b/test/simpletest/socket.php
@@ -138,7 +138,10 @@ class SimpleFileSocket extends SimpleStickyError {
     function close() {
         if (!$this->is_open) return false;
         $this->is_open = false;
-        return fclose($this->handle);
+        if (is_resource($this->handle)) {
+            return fclose($this->handle);
+        }
+        return false;
     }
 
     /**
@@ -252,7 +255,10 @@ class SimpleSocket extends SimpleStickyError {
      */
     function close() {
         $this->is_open = false;
-        return fclose($this->handle);
+        if (is_resource($this->handle)) {
+            return fclose($this->handle);
+        }
+        return false;
     }
 
     /**

--- a/test/simpletest/tag.php
+++ b/test/simpletest/tag.php
@@ -845,7 +845,7 @@ class SimpleSelectionTag extends SimpleWidget {
      *    @access public
      */
     function getDefault() {
-        for ($i = 0, $count = count($this->options); $i < $count; $i++) {
+        for ($i = 0, $count = SimpleTestCompatibility::count($this->options); $i < $count; $i++) {
             if ($this->options[$i]->getAttribute('selected') !== false) {
                 return $this->options[$i]->getDefault();
             }
@@ -863,7 +863,7 @@ class SimpleSelectionTag extends SimpleWidget {
      *    @access public
      */
     function setValue($value) {
-        for ($i = 0, $count = count($this->options); $i < $count; $i++) {
+        for ($i = 0, $count = SimpleTestCompatibility::count($this->options); $i < $count; $i++) {
             if ($this->options[$i]->isValue($value)) {
                 $this->choice = $i;
                 return true;
@@ -934,7 +934,7 @@ class MultipleSelectionTag extends SimpleWidget {
      */
     function getDefault() {
         $default = array();
-        for ($i = 0, $count = count($this->options); $i < $count; $i++) {
+        for ($i = 0, $count = SimpleTestCompatibility::count($this->options); $i < $count; $i++) {
             if ($this->options[$i]->getAttribute('selected') !== false) {
                 $default[] = $this->options[$i]->getDefault();
             }
@@ -954,7 +954,7 @@ class MultipleSelectionTag extends SimpleWidget {
         $achieved = array();
         foreach ($desired as $value) {
             $success = false;
-            for ($i = 0, $count = count($this->options); $i < $count; $i++) {
+            for ($i = 0, $count = SimpleTestCompatibility::count($this->options); $i < $count; $i++) {
                 if ($this->options[$i]->isValue($value)) {
                     $achieved[] = $this->options[$i]->getValue();
                     $success = true;
@@ -1207,7 +1207,7 @@ class SimpleTagGroup {
      *    @access public
      */
     function getName() {
-        if (count($this->widgets) > 0) {
+        if (SimpleTestCompatibility::count($this->widgets) > 0) {
             return $this->widgets[0]->getName();
         }
     }
@@ -1220,7 +1220,7 @@ class SimpleTagGroup {
      *    @access public
      */
     function isId($id) {
-        for ($i = 0, $count = count($this->widgets); $i < $count; $i++) {
+        for ($i = 0, $count = SimpleTestCompatibility::count($this->widgets); $i < $count; $i++) {
             if ($this->widgets[$i]->isId($id)) {
                 return true;
             }
@@ -1236,7 +1236,7 @@ class SimpleTagGroup {
      *    @access public
      */
     function isLabel($label) {
-        for ($i = 0, $count = count($this->widgets); $i < $count; $i++) {
+        for ($i = 0, $count = SimpleTestCompatibility::count($this->widgets); $i < $count; $i++) {
             if ($this->widgets[$i]->isLabel($label)) {
                 return true;
             }
@@ -1270,7 +1270,7 @@ class SimpleCheckboxGroup extends SimpleTagGroup {
     function getValue() {
         $values = array();
         $widgets = $this->getWidgets();
-        for ($i = 0, $count = count($widgets); $i < $count; $i++) {
+        for ($i = 0, $count = SimpleTestCompatibility::count($widgets); $i < $count; $i++) {
             if ($widgets[$i]->getValue() !== false) {
                 $values[] = $widgets[$i]->getValue();
             }
@@ -1286,7 +1286,7 @@ class SimpleCheckboxGroup extends SimpleTagGroup {
     function getDefault() {
         $values = array();
         $widgets = $this->getWidgets();
-        for ($i = 0, $count = count($widgets); $i < $count; $i++) {
+        for ($i = 0, $count = SimpleTestCompatibility::count($widgets); $i < $count; $i++) {
             if ($widgets[$i]->getDefault() !== false) {
                 $values[] = $widgets[$i]->getDefault();
             }
@@ -1307,7 +1307,7 @@ class SimpleCheckboxGroup extends SimpleTagGroup {
             return false;
         }
         $widgets = $this->getWidgets();
-        for ($i = 0, $count = count($widgets); $i < $count; $i++) {
+        for ($i = 0, $count = SimpleTestCompatibility::count($widgets); $i < $count; $i++) {
             $possible = $widgets[$i]->getAttribute('value');
             if (in_array($widgets[$i]->getAttribute('value'), $values)) {
                 $widgets[$i]->setValue($possible);
@@ -1329,7 +1329,7 @@ class SimpleCheckboxGroup extends SimpleTagGroup {
     protected function valuesArePossible($values) {
         $matches = array();
         $widgets = &$this->getWidgets();
-        for ($i = 0, $count = count($widgets); $i < $count; $i++) {
+        for ($i = 0, $count = SimpleTestCompatibility::count($widgets); $i < $count; $i++) {
             $possible = $widgets[$i]->getAttribute('value');
             if (in_array($possible, $values)) {
                 $matches[] = $possible;
@@ -1347,9 +1347,9 @@ class SimpleCheckboxGroup extends SimpleTagGroup {
      *    @access private
      */
     protected function coerceValues($values) {
-        if (count($values) == 0) {
+        if (SimpleTestCompatibility::count($values) == 0) {
             return false;
-        } elseif (count($values) == 1) {
+        } elseif (SimpleTestCompatibility::count($values) == 1) {
             return $values[0];
         } else {
             return $values;
@@ -1398,7 +1398,7 @@ class SimpleRadioGroup extends SimpleTagGroup {
         }
         $index = false;
         $widgets = $this->getWidgets();
-        for ($i = 0, $count = count($widgets); $i < $count; $i++) {
+        for ($i = 0, $count = SimpleTestCompatibility::count($widgets); $i < $count; $i++) {
             if (! $widgets[$i]->setValue($value)) {
                 $widgets[$i]->setValue(false);
             }
@@ -1414,7 +1414,7 @@ class SimpleRadioGroup extends SimpleTagGroup {
      */
     protected function valueIsPossible($value) {
         $widgets = $this->getWidgets();
-        for ($i = 0, $count = count($widgets); $i < $count; $i++) {
+        for ($i = 0, $count = SimpleTestCompatibility::count($widgets); $i < $count; $i++) {
             if ($widgets[$i]->getAttribute('value') == $value) {
                 return true;
             }
@@ -1431,7 +1431,7 @@ class SimpleRadioGroup extends SimpleTagGroup {
      */
     function getValue() {
         $widgets = $this->getWidgets();
-        for ($i = 0, $count = count($widgets); $i < $count; $i++) {
+        for ($i = 0, $count = SimpleTestCompatibility::count($widgets); $i < $count; $i++) {
             if ($widgets[$i]->getValue() !== false) {
                 return $widgets[$i]->getValue();
             }
@@ -1447,7 +1447,7 @@ class SimpleRadioGroup extends SimpleTagGroup {
      */
     function getDefault() {
         $widgets = $this->getWidgets();
-        for ($i = 0, $count = count($widgets); $i < $count; $i++) {
+        for ($i = 0, $count = SimpleTestCompatibility::count($widgets); $i < $count; $i++) {
             if ($widgets[$i]->getDefault() !== false) {
                 return $widgets[$i]->getDefault();
             }

--- a/test/simpletest/test/form_test.php
+++ b/test/simpletest/test/form_test.php
@@ -218,7 +218,7 @@ class TestOfForm extends UnitTestCase {
         $form->setField(new SimpleByLabelOrName('elements[]'), '4', 2);
 		$submit = $form->submit();
 		$requests = $submit->getAll();
-        $this->assertEqual(count($requests), 2);
+        $this->assertEqual(SimpleTestCompatibility::count($requests), 2);
         $this->assertIdentical($requests[0], new SimpleEncodedPair('elements[]', '3'));
         $this->assertIdentical($requests[1], new SimpleEncodedPair('elements[]', '4'));
     }

--- a/test/simpletest/test/php_parser_test.php
+++ b/test/simpletest/test/php_parser_test.php
@@ -149,10 +149,10 @@ class TestOfLexer extends UnitTestCase {
     function testMultiplePattern() {
         $handler = new MockTestParser();
         $target = array("a", "b", "a", "bb", "x", "b", "a", "xxxxxx", "a", "x");
-        for ($i = 0; $i < count($target); $i++) {
+        for ($i = 0; $i < SimpleTestCompatibility::count($target); $i++) {
             $handler->expectAt($i, "accept", array($target[$i], '*'));
         }
-        $handler->expectCallCount("accept", count($target));
+        $handler->expectCallCount("accept", SimpleTestCompatibility::count($target));
         $handler->setReturnValue("accept", true);
         $lexer = new SimpleLexer($handler);
         $lexer->addPattern("a+");

--- a/test/simpletest/test/recorder_test.php
+++ b/test/simpletest/test/recorder_test.php
@@ -10,7 +10,7 @@ class TestOfRecorder extends UnitTestCase {
         $test->addFile(dirname(__FILE__) . '/support/recorder_sample.php');
         $recorder = new Recorder(new SimpleReporter());
         $test->run($recorder);
-        $this->assertEqual(count($recorder->results), 2);
+        $this->assertEqual(SimpleTestCompatibility::count($recorder->results), 2);
         $this->assertIsA($recorder->results[0], 'SimpleResultOfPass');
         $this->assertEqual('testTrueIsTrue', array_pop($recorder->results[0]->breadcrumb));
         $this->assertPattern('/ at \[.*\Wrecorder_sample\.php line 7\]/', $recorder->results[0]->message);

--- a/test/simpletest/test/reflection_php5_test.php
+++ b/test/simpletest/test/reflection_php5_test.php
@@ -205,7 +205,7 @@ class TestOfReflection extends UnitTestCase {
 	function testProperlyReflectsTheFinalInterfaceWhenObjectImplementsAnExtendedInterface() {
 		$reflection = new SimpleReflection('AnyDescendentImplementation');
 		$interfaces = $reflection->getInterfaces();
-		$this->assertEqual(1, count($interfaces));
+		$this->assertEqual(1, SimpleTestCompatibility::count($interfaces));
 		$this->assertEqual('AnyDescendentInterface', array_shift($interfaces));
 	}
 	

--- a/test/simpletest/test_case.php
+++ b/test/simpletest/test_case.php
@@ -220,7 +220,7 @@ class SimpleTestCase {
      *    @access public
      */
     function after($method) {
-        for ($i = 0; $i < count($this->observers); $i++) {
+        for ($i = 0; $i < SimpleTestCompatibility::count($this->observers); $i++) {
             $this->observers[$i]->atTestEnd($method, $this);
         }
         $this->reporter->paintMethodEnd($method);
@@ -453,7 +453,7 @@ class SimpleFileLoader {
      *    @access public
      */
     function createSuiteFromClasses($title, $classes) {
-        if (count($classes) == 0) {
+        if (SimpleTestCompatibility::count($classes) == 0) {
             $suite = new BadTestSuite($title, "No runnable test cases in [$title]");
             return $suite;
         }
@@ -557,7 +557,7 @@ class TestSuite {
      */
     function run($reporter) {
         $reporter->paintGroupStart($this->getLabel(), $this->getSize());
-        for ($i = 0, $count = count($this->test_cases); $i < $count; $i++) {
+        for ($i = 0, $count = SimpleTestCompatibility::count($this->test_cases); $i < $count; $i++) {
             if (is_string($this->test_cases[$i])) {
                 $class = $this->test_cases[$i];
                 $test = new $class();

--- a/test/simpletest/tidy_parser.php
+++ b/test/simpletest/tidy_parser.php
@@ -303,7 +303,7 @@ class SimpleTidyPageBuilder {
      */
     private function mergeAttribute($attributes, $raw) {
         $parts = explode('=', $raw);
-        list($name, $value) = count($parts) == 1 ? array($parts[0], $parts[0]) : $parts;
+        list($name, $value) = SimpleTestCompatibility::count($parts) == 1 ? array($parts[0], $parts[0]) : $parts;
         $attributes[trim($name)] = html_entity_decode($this->dequote(trim($value)), ENT_QUOTES);
         return $attributes;
     }

--- a/test/simpletest/web_tester.php
+++ b/test/simpletest/web_tester.php
@@ -77,7 +77,7 @@ class FieldExpectation extends SimpleExpectation {
      *    @access private
      */
     protected function testSingle($compare) {
-        if (is_array($compare) && count($compare) == 1) {
+        if (is_array($compare) && SimpleTestCompatibility::count($compare) == 1) {
             $compare = $compare[0];
         }
         if (! $this->isSingle($compare)) {
@@ -206,7 +206,7 @@ class HttpHeaderExpectation extends SimpleExpectation {
      *    @access private
      */
     protected function testHeaderLine($line) {
-        if (count($parsed = explode(':', $line, 2)) < 2) {
+        if (SimpleTestCompatibility::count($parsed = explode(':', $line, 2)) < 2) {
             return false;
         }
         list($header, $value) = $parsed;

--- a/test/simpletest/xml.php
+++ b/test/simpletest/xml.php
@@ -44,7 +44,7 @@ class XmlReporter extends SimpleReporter {
     protected function getIndent($offset = 0) {
         return str_repeat(
                 $this->indent,
-                count($this->getTestList()) + $offset);
+                SimpleTestCompatibility::count($this->getTestList()) + $offset);
     }
 
     /**


### PR DESCRIPTION
This PR patches the internal SimpleTest framework to be compatible with PHP 8.x. It introduces a compatibility wrapper for `count()` to handle non-countable types and hardens `fclose()` calls in `socket.php`. The `MIGRATION_ROADMAP.md` and `ROADMAP.md` have been updated to reflect the completion of this step.

Fixes #64

---
*PR created automatically by Jules for task [11206729678903529476](https://jules.google.com/task/11206729678903529476) started by @chatelao*