### PR TITLE
Resolve session warnings and refine migration roadmap

### DIFF
--- a/MIGRATION_ROADMAP.md
+++ b/MIGRATION_ROADMAP.md
@@ -22,11 +22,14 @@ This document outlines the detailed, granular steps for modernizing and migratin
     - [x] **Harden `mysql_shim.php`**: (Completed: 2025-05-22) Added explicit `instanceof` checks for all parameters passed to `mysqli_*` functions to prevent `TypeError`.
     - [x] **Patch SimpleTest core for PHP 8.x**: (Completed: 2026-04-27) Added `SimpleTestCompatibility::count()` and updated all call sites in `test/simpletest/` to handle non-countable types. Also hardened `socket.php` against `fclose()` TypeErrors.
     - [x] **Fix PHP-gettext fatal error on PHP 8.x**: (Completed: 2026-04-27) Updated legacy constructors to `__construct()` in `lib/gettext/` to support PHP 8.0+.
-    - [ ] **Resolve session warnings**: Address `session_start()` and other session-related warnings that became more strict in PHP 8.x.
+    - [x] **Resolve session warnings**: (Completed: 2026-04-27) Added `session_status()` checks before `session_start()` in `signin/` and `hybridauth/` to prevent PHP 8.x warnings when a session is already active.
 - [ ] **Responsive UI**: Implement a mobile-first responsive design using modern CSS (Flexbox/Grid).
 - [ ] **Database Layer Refactor**
     - [x] **Audit legacy usage**: (Completed: 2026-04-27) Identified and documented all `mysql_*` function calls in `TECHNICAL_DEBTS_MYSQL.md`.
-    - [ ] **Design Abstraction Layer**: Create a `mysqli`-based database wrapper or select a lightweight Query Builder.
+    - [ ] **Design Abstraction Layer**
+        - [ ] Define the DBAL interface (Connection, Query, Fetch, Escape).
+        - [ ] Implement the core DBAL class using `mysqli`.
+        - [ ] Implement support for prepared statements in the DBAL.
     - [ ] **Migrate Connection Logic**: Update `include/dbconnect.php` to use the new abstraction.
     - [ ] **Phased Migration**: Systematically replace `mysql_shim.php` calls with the new abstraction.
 

--- a/hybridauth/Hybrid/Storage.php
+++ b/hybridauth/Hybrid/Storage.php
@@ -12,7 +12,7 @@ class Hybrid_Storage
 {
 	function __construct()
 	{ 
-		if ( ! session_id() ){
+		if ( session_status() === PHP_SESSION_NONE ){
 			if( ! session_start() ){
 				throw new Exception( "Hybridauth requires the use of 'session_start()' at the start of your script, which appears to be disabled.", 1 );
 			}

--- a/hybridauth/Hybrid/thirdparty/Facebook/facebook.php
+++ b/hybridauth/Hybrid/thirdparty/Facebook/facebook.php
@@ -33,7 +33,7 @@ class Facebook extends BaseFacebook
    * @see BaseFacebook::__construct in facebook.php
    */
   public function __construct($config) {
-    if (!session_id()) {
+    if (session_status() === PHP_SESSION_NONE) {
       session_start();
     }
     parent::__construct($config);

--- a/signin/models/captcha.php
+++ b/signin/models/captcha.php
@@ -3,7 +3,9 @@
 UserCake Version: 2.0.1
 http://usercake.com
 */
-session_start();
+if (session_status() === PHP_SESSION_NONE) {
+    session_start();
+}
 $md5_hash = md5(rand(0,99999)); 
 $security_code = substr($md5_hash, 25, 5); 
 $enc = md5($security_code);

--- a/signin/models/config.php
+++ b/signin/models/config.php
@@ -46,7 +46,9 @@ require_once("class.user.php");
 require_once("class.newuser.php");
 require_once("funcs.php");
 
-session_start();
+if (session_status() === PHP_SESSION_NONE) {
+    session_start();
+}
 
 //Global User Object Var
 //loggedInUser can be used globally if constructed


### PR DESCRIPTION
This PR addresses two objectives from the migration roadmap:

1. **Granular Roadmap Refinement**: The broad "Design Abstraction Layer" task has been broken down into three specific sub-tasks to facilitate more manageable future work.
2. **PHP 8.x Compatibility**: Resolved persistent session warnings that occur on PHP 8.x when `session_start()` is called while a session is already active. This was achieved by wrapping `session_start()` with `session_status() === PHP_SESSION_NONE` checks in the `signin` module and standardizing the existing session checks in the `hybridauth` library.

The "Resolve session warnings" task has been marked as completed in `MIGRATION_ROADMAP.md`.

Verification:
- Translation tests passed successfully.
- Server logs confirmed the absence of session-related warnings during test execution.

Fixes #68

---
*PR created automatically by Jules for task [14222902403135461748](https://jules.google.com/task/14222902403135461748) started by @chatelao*