### PR TITLE
Modernize Roadmap and Implement Core DBAL

### DIFF
--- a/MIGRATION_ROADMAP.md
+++ b/MIGRATION_ROADMAP.md
@@ -23,12 +23,16 @@ This document outlines the detailed, granular steps for modernizing and migratin
     - [x] **Patch SimpleTest core for PHP 8.x**: (Completed: 2026-04-27) Added `SimpleTestCompatibility::count()` and updated all call sites in `test/simpletest/` to handle non-countable types. Also hardened `socket.php` against `fclose()` TypeErrors.
     - [x] **Fix PHP-gettext fatal error on PHP 8.x**: (Completed: 2026-04-27) Updated legacy constructors to `__construct()` in `lib/gettext/` to support PHP 8.0+.
     - [x] **Resolve session warnings**: (Completed: 2026-04-27) Added `session_status()` checks before `session_start()` in `signin/` and `hybridauth/` to prevent PHP 8.x warnings when a session is already active.
-- [ ] **Responsive UI**: Implement a mobile-first responsive design using modern CSS (Flexbox/Grid).
+- [ ] **Responsive UI**
+    - [ ] Add viewport meta tag to `include/header.inc.php`.
+    - [ ] Convert fixed-width layout (`#container`) to fluid/responsive.
+    - [ ] Implement a mobile-friendly navigation menu.
+    - [ ] Implement responsive table patterns for the main contact list.
 - [ ] **Database Layer Refactor**
     - [x] **Audit legacy usage**: (Completed: 2026-04-27) Identified and documented all `mysql_*` function calls in `TECHNICAL_DEBTS_MYSQL.md`.
     - [ ] **Design Abstraction Layer**
-        - [ ] Define the DBAL interface (Connection, Query, Fetch, Escape).
-        - [ ] Implement the core DBAL class using `mysqli`.
+        - [x] **Define the DBAL interface**: (Completed: 2026-04-27) Created `include/database.interface.php` defining the core database operations.
+        - [x] **Implement the core DBAL class using `mysqli`**: (Completed: 2026-04-27) Created `include/mysqli.database.php` as the primary implementation.
         - [ ] Implement support for prepared statements in the DBAL.
     - [ ] **Migrate Connection Logic**: Update `include/dbconnect.php` to use the new abstraction.
     - [ ] **Phased Migration**: Systematically replace `mysql_shim.php` calls with the new abstraction.
@@ -36,13 +40,17 @@ This document outlines the detailed, granular steps for modernizing and migratin
 ### Phase 3: Technical Debt Cleanup
 - [ ] **Remove MooTools**: Completely remove MooTools 1.11 and migrate `jscalendar` to a modern, lightweight date picker like **Flatpickr**.
 - [x] **Modernize Table Actions**: (Completed: 2026-04-27) Removed the unreferenced `js/tableActions.min.js`. Further modernization can focus on native JS or future DataTables integration if needed.
-- [ ] **Migrate Testing Framework**: Transition from SimpleTest to **PHPUnit** for more robust testing and PHP 8.x compatibility.
+- [ ] **Migrate Testing Framework**
+    - [ ] Setup PHPUnit (Configuration and initial test suite).
+    - [ ] Migrate core library tests to PHPUnit.
+    - [ ] Migrate web/integration tests to PHPUnit.
+    - [ ] Remove SimpleTest once migration is complete.
 
 ### Ongoing Modernization
 - [ ] **Upgrade parseCSV**: Update `lib/parsecsv.lib.php` from 0.4.3 beta to the active fork version 1.3.x.
 - [ ] **Modernize Translation Engine**: Replace legacy **PHP-gettext 1.0** with native PHP gettext or Symfony Translation.
 - [ ] **Modernize Identicon Generation**: Replace the local `lib/identicon.php` with a modern library like `bit-wasp/identicon`.
-- [ ] **Modernize Table Sorting**: Replace the legacy `js/tablesort.min.js` with native DataTables sorting capabilities.
+- [ ] **Modernize Table Sorting**: Replace the legacy `js/tablesort.min.js` with native Vanilla JS sorting capabilities.
 
 ---
 

--- a/include/database.interface.php
+++ b/include/database.interface.php
@@ -1,0 +1,71 @@
+<?php
+
+/**
+ * Database Abstraction Layer Interface
+ */
+interface DatabaseInterface {
+    /**
+     * Connect to the database server
+     */
+    public function connect($server, $username, $password, $new_link = false, $client_flags = 0);
+
+    /**
+     * Select a database
+     */
+    public function selectDb($database_name);
+
+    /**
+     * Execute a query
+     */
+    public function query($query);
+
+    /**
+     * Fetch a result row as an associative, a numeric array, or both
+     */
+    public function fetchArray($result, $result_type = MYSQLI_BOTH);
+
+    /**
+     * Fetch a result row as an associative array
+     */
+    public function fetchAssoc($result);
+
+    /**
+     * Fetch a result row as a numeric array
+     */
+    public function fetchRow($result);
+
+    /**
+     * Get the number of rows in a result
+     */
+    public function numRows($result);
+
+    /**
+     * Get the last error message
+     */
+    public function error();
+
+    /**
+     * Get the last error number
+     */
+    public function errno();
+
+    /**
+     * Escapes special characters in a string for use in an SQL statement
+     */
+    public function realEscapeString($unescaped_string);
+
+    /**
+     * Close the database connection
+     */
+    public function close();
+
+    /**
+     * Move the internal result pointer
+     */
+    public function dataSeek($result, $row_number);
+
+    /**
+     * Get the ID generated in the last query
+     */
+    public function insertId();
+}

--- a/include/mysqli.database.php
+++ b/include/mysqli.database.php
@@ -1,0 +1,79 @@
+<?php
+
+require_once __DIR__ . DIRECTORY_SEPARATOR . "database.interface.php";
+
+/**
+ * MySQLi Implementation of the Database Abstraction Layer
+ */
+class MysqliDatabase implements DatabaseInterface {
+    private $link;
+
+    public function connect($server, $username, $password, $new_link = false, $client_flags = 0) {
+        try {
+            $this->link = mysqli_connect($server, $username, $password);
+        } catch (Exception $e) {
+            $this->link = false;
+        }
+        return $this->link;
+    }
+
+    public function selectDb($database_name) {
+        if (!($this->link instanceof mysqli)) return false;
+        return mysqli_select_db($this->link, $database_name);
+    }
+
+    public function query($query) {
+        if (!($this->link instanceof mysqli)) return false;
+        return mysqli_query($this->link, $query);
+    }
+
+    public function fetchArray($result, $result_type = MYSQLI_BOTH) {
+        if (!($result instanceof mysqli_result)) return false;
+        return mysqli_fetch_array($result, $result_type);
+    }
+
+    public function fetchAssoc($result) {
+        if (!($result instanceof mysqli_result)) return false;
+        return mysqli_fetch_assoc($result);
+    }
+
+    public function fetchRow($result) {
+        if (!($result instanceof mysqli_result)) return false;
+        return mysqli_fetch_row($result);
+    }
+
+    public function numRows($result) {
+        if (!($result instanceof mysqli_result)) return 0;
+        return mysqli_num_rows($result);
+    }
+
+    public function error() {
+        if (!($this->link instanceof mysqli)) return "";
+        return mysqli_error($this->link);
+    }
+
+    public function errno() {
+        if (!($this->link instanceof mysqli)) return 0;
+        return mysqli_errno($this->link);
+    }
+
+    public function realEscapeString($unescaped_string) {
+        if (!($this->link instanceof mysqli)) return addslashes($unescaped_string);
+        return mysqli_real_escape_string($this->link, $unescaped_string);
+    }
+
+    public function close() {
+        if (!($this->link instanceof mysqli)) return true;
+        return mysqli_close($this->link);
+    }
+
+    public function dataSeek($result, $row_number) {
+        if (!($result instanceof mysqli_result)) return false;
+        return mysqli_data_seek($result, $row_number);
+    }
+
+    public function insertId() {
+        if (!($this->link instanceof mysqli)) return 0;
+        return mysqli_insert_id($this->link);
+    }
+}


### PR DESCRIPTION
This PR modernizes the project's migration roadmap by breaking down large, vague tasks into manageable sub-steps and implements the first foundational step of the Database Layer Refactor.

Key changes:
- **Roadmap Refinement**: `MIGRATION_ROADMAP.md` now details specific tasks for "Responsive UI" and "Migrate Testing Framework".
- **DBAL Foundation**: Introduced `include/database.interface.php` to define a standard for database operations and `include/mysqli.database.php` as its primary implementation. This facilitates a phased migration away from the deprecated `mysql` extension and the temporary `mysql_shim.php` layer.
- **Documentation Update**: Updated `MIGRATION_ROADMAP.md` to reflect the completion of the DBAL interface and initial implementation.

Fixes #70

---
*PR created automatically by Jules for task [6498941371813277140](https://jules.google.com/task/6498941371813277140) started by @chatelao*