### PR TITLE
Implement DBAL Prepared Statements

### DIFF
--- a/MIGRATION_ROADMAP.md
+++ b/MIGRATION_ROADMAP.md
@@ -33,7 +33,7 @@ This document outlines the detailed, granular steps for modernizing and migratin
     - [ ] **Design Abstraction Layer**
         - [x] **Define the DBAL interface**: (Completed: 2026-04-27) Created `include/database.interface.php` defining the core database operations.
         - [x] **Implement the core DBAL class using `mysqli`**: (Completed: 2026-04-27) Created `include/mysqli.database.php` as the primary implementation.
-        - [ ] Implement support for prepared statements in the DBAL.
+        - [x] **Implement support for prepared statements in the DBAL**: (Completed: 2026-04-27) Added `execute` method to `DatabaseInterface` and implemented it in `MysqliDatabase` using `mysqli_execute_query` with a fallback for PHP < 8.2.
     - [ ] **Migrate Connection Logic**: Update `include/dbconnect.php` to use the new abstraction.
     - [ ] **Phased Migration**: Systematically replace `mysql_shim.php` calls with the new abstraction.
 

--- a/include/database.interface.php
+++ b/include/database.interface.php
@@ -68,4 +68,13 @@ interface DatabaseInterface {
      * Get the ID generated in the last query
      */
     public function insertId();
+
+    /**
+     * Execute a query with parameters using prepared statements
+     *
+     * @param string $query The SQL query with placeholders (?)
+     * @param array $params The parameters to bind to the placeholders
+     * @return mixed The result of the query (mysqli_result for SELECT, bool for others)
+     */
+    public function execute($query, array $params = []);
 }

--- a/include/mysqli.database.php
+++ b/include/mysqli.database.php
@@ -76,4 +76,41 @@ class MysqliDatabase implements DatabaseInterface {
         if (!($this->link instanceof mysqli)) return 0;
         return mysqli_insert_id($this->link);
     }
+
+    public function execute($query, array $params = []) {
+        if (!($this->link instanceof mysqli)) return false;
+
+        if (function_exists('mysqli_execute_query')) {
+            return mysqli_execute_query($this->link, $query, $params);
+        }
+
+        // Fallback for PHP < 8.2
+        $stmt = mysqli_prepare($this->link, $query);
+        if (!$stmt) return false;
+
+        if (!empty($params)) {
+            $types = "";
+            foreach ($params as $param) {
+                if (is_int($param)) $types .= "i";
+                elseif (is_double($param)) $types .= "d";
+                elseif (is_string($param)) $types .= "s";
+                else $types .= "b";
+            }
+            mysqli_stmt_bind_param($stmt, $types, ...$params);
+        }
+
+        if (!mysqli_stmt_execute($stmt)) {
+            mysqli_stmt_close($stmt);
+            return false;
+        }
+
+        $result = mysqli_stmt_get_result($stmt);
+        if ($result === false && mysqli_stmt_errno($stmt) === 0) {
+            // For non-SELECT queries that succeeded
+            $result = true;
+        }
+
+        mysqli_stmt_close($stmt);
+        return $result;
+    }
 }


### PR DESCRIPTION
Added support for prepared statements to the Database Abstraction Layer. Implemented the 'execute' method in 'DatabaseInterface' and 'MysqliDatabase' using 'mysqli_execute_query' (PHP 8.2+) with a robust fallback for older PHP versions. Updated the migration roadmap to reflect this progress.

Fixes #74

---
*PR created automatically by Jules for task [2733517471478281903](https://jules.google.com/task/2733517471478281903) started by @chatelao*