### PR TITLE
Migrate Database Connection to DBAL and Refine Roadmap

### DIFF
--- a/MIGRATION_ROADMAP.md
+++ b/MIGRATION_ROADMAP.md
@@ -34,8 +34,14 @@ This document outlines the detailed, granular steps for modernizing and migratin
         - [x] **Define the DBAL interface**: (Completed: 2026-04-27) Created `include/database.interface.php` defining the core database operations.
         - [x] **Implement the core DBAL class using `mysqli`**: (Completed: 2026-04-27) Created `include/mysqli.database.php` as the primary implementation.
         - [x] **Implement support for prepared statements in the DBAL**: (Completed: 2026-04-27) Added `execute` method to `DatabaseInterface` and implemented it in `MysqliDatabase` using `mysqli_execute_query` with a fallback for PHP < 8.2.
-    - [ ] **Migrate Connection Logic**: Update `include/dbconnect.php` to use the new abstraction.
+    - [x] **Migrate Connection Logic**: (Completed: 2026-04-27) Updated `include/dbconnect.php` to use the `MysqliDatabase` abstraction while maintaining backward compatibility.
     - [ ] **Phased Migration**: Systematically replace `mysql_shim.php` calls with the new abstraction.
+        - [ ] Migrate `include/address.class.php` to DBAL.
+        - [ ] Migrate `include/group.class.php` and `group.php` to DBAL.
+        - [ ] Migrate `include/login.inc.php` and authentication files to DBAL.
+        - [ ] Migrate core pages (`index.php`, `edit.php`, `view.php`, `birthdays.php`) to DBAL.
+        - [ ] Migrate registration module (`register/`) to DBAL.
+        - [ ] Migrate Z-Push backend to DBAL.
 
 ### Phase 3: Technical Debt Cleanup
 - [ ] **Remove MooTools**: Completely remove MooTools 1.11 and migrate `jscalendar` to a modern, lightweight date picker like **Flatpickr**.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -24,7 +24,7 @@ This document outlines the planned improvements and modernization steps for the 
 - [ ] **Remove MooTools**: Completely remove MooTools 1.11 and migrate `jscalendar` to a modern, lightweight date picker like **Flatpickr**.
 
 ### Phase 2: Core Improvements
-- [ ] **Database Layer Refactor**: Transition from the `mysql_shim.php` compatibility layer to native `mysqli` or a modern ORM/Query Builder.
+- [ ] **Database Layer Refactor**: (Partially Completed: 2026-04-27) Defined DBAL interface, implemented `MysqliDatabase` with prepared statement support, and migrated core connection logic in `include/dbconnect.php`. Transition from the `mysql_shim.php` compatibility layer to native `mysqli` or a modern ORM/Query Builder.
 - [ ] **Responsive UI**: (Partially Completed: 2026-04-27) Modernized viewport meta tag and converted fixed-width layout to fluid. Further work needed for mobile navigation and tables.
 - [ ] **PHP 8.x Native Support**: (Partially Completed: 2026-04-27) Hardened `mysql_shim.php` (2025) and patched SimpleTest core (2026) to handle PHP 8.x `count()` and `fclose()` changes. Further work needed on legacy libraries like PHP-gettext.
 

--- a/include/dbconnect.php
+++ b/include/dbconnect.php
@@ -1,5 +1,9 @@
 <?php
 require_once(dirname(__FILE__).DIRECTORY_SEPARATOR."mysql_shim.php");
+require_once(dirname(__FILE__).DIRECTORY_SEPARATOR."mysqli.database.php");
+
+$db_access = new MysqliDatabase();
+
 /*
  * Core file for library and parameter handling:
  *
@@ -40,13 +44,10 @@ if($read_only) {
 
 // --- Connect to DB, retry 5 times ---
 for ($i = 0; $i < 5; $i++) {
-	
-    $level = error_reporting();
-    error_reporting(E_ERROR);
-    $db = mysql_connect("$dbserver", "$dbuser", "$dbpass");
-    error_reporting($level);
-    
-    $errno = mysql_errno();
+    $db = $db_access->connect($dbserver, $dbuser, $dbpass);
+    $GLOBALS["mysql_mysqli_link"] = $db;
+
+    $errno = $db_access->errno();
     if ($errno == 1040 || $errno == 1226 || $errno == 1203) {
         sleep(1);
     }  else {
@@ -208,18 +209,19 @@ include("translations.inc.php");
 include("mailer.inc.php");
 if(!$db) {
 	include "include/install.php";
-}
-mysql_select_db("$dbname", $db);  
-//
-// Setup the UTF-8 parameters:
-// * http://www.phpforum.de/forum/showthread.php?t=217877#PHP
-//
-// header('Content-type: text/html; charset=utf-8');
-mysql_query("set character set utf8;");
-mysql_query("SET NAMES `utf8`");
+} else {
+    $db_access->selectDb($dbname);
+    //
+    // Setup the UTF-8 parameters:
+    // * http://www.phpforum.de/forum/showthread.php?t=217877#PHP
+    //
+    // header('Content-type: text/html; charset=utf-8');
+    $db_access->query("set character set utf8;");
+    $db_access->query("SET NAMES `utf8` ");
 
-// Bug: #139 - Strict mode problem
-mysql_query("SET SQL_MODE = 'STRICT_TRANS_TABLES';");
+    // Bug: #139 - Strict mode problem
+    $db_access->query("SET SQL_MODE = 'STRICT_TRANS_TABLES'");
+}
 // mysql_query("SET SQL_MODE = 'MYSQL40';");
 
 include("login.inc.php");

--- a/include/mysqli.database.php
+++ b/include/mysqli.database.php
@@ -80,7 +80,8 @@ class MysqliDatabase implements DatabaseInterface {
     public function execute($query, array $params = []) {
         if (!($this->link instanceof mysqli)) return false;
 
-        if (function_exists('mysqli_execute_query')) {
+        // mysqli_execute_query is PHP 8.2+
+        if (version_compare(PHP_VERSION, '8.2.0', '>=') && function_exists('mysqli_execute_query')) {
             return mysqli_execute_query($this->link, $query, $params);
         }
 
@@ -96,7 +97,11 @@ class MysqliDatabase implements DatabaseInterface {
                 elseif (is_string($param)) $types .= "s";
                 else $types .= "b";
             }
-            mysqli_stmt_bind_param($stmt, $types, ...$params);
+            $bind_names = array($stmt, $types);
+            foreach ($params as $key => $value) {
+                $bind_names[] = &$params[$key];
+            }
+            call_user_func_array('mysqli_stmt_bind_param', $bind_names);
         }
 
         if (!mysqli_stmt_execute($stmt)) {


### PR DESCRIPTION
I have implemented the next modest and reasonable step in the modernization roadmap: migrating the core database connection logic to the newly created Database Abstraction Layer (DBAL).

Key changes:
1.  **Roadmap Refinement**: Broken down the large "Phased Migration" task in `MIGRATION_ROADMAP.md` into smaller, manageable sub-tasks organized by module (e.g., core classes, authentication, core pages). This provides a clearer path for future work.
2.  **Connection Logic Migration**: Updated `include/dbconnect.php` to use the `MysqliDatabase` class for establishing the database connection and selecting the database. 
3.  **Backward Compatibility**: Ensured that the global `$db` and `$GLOBALS['mysql_mysqli_link']` are still correctly populated after connection, allowing the legacy `mysql_shim.php` to continue functioning during the transition.
4.  **Foundation for Future Steps**: Introduced a global `$db_access` variable which provides a modern interface (including prepared statement support) for future migration of individual queries.
5.  **Documentation Update**: Marked the "Migrate Connection Logic" task as completed in both `ROADMAP.md` and `MIGRATION_ROADMAP.md`.

These changes were verified using the existing SimpleTest suite to ensure no regressions were introduced to the application's core functionality.

Fixes #76

---
*PR created automatically by Jules for task [16503739195879543537](https://jules.google.com/task/16503739195879543537) started by @chatelao*