### PR TITLE
Migrate registration module core to DBAL

### DIFF
--- a/MIGRATION_ROADMAP.md
+++ b/MIGRATION_ROADMAP.md
@@ -42,7 +42,23 @@ This document outlines the detailed, granular steps for modernizing and migratin
         - [ ] Migrate `view.php` to DBAL.
         - [ ] Migrate `birthdays.php` to DBAL.
         - [ ] Migrate `delete.php` and `photo.php` to DBAL.
-        - [ ] Migrate registration module (`register/`) to DBAL.
+        - [ ] Migrate registration module (`register/`) to DBAL:
+            - [ ] Migrate `register/user_add_save.php` to DBAL.
+            - [ ] Migrate `register/login_config.php` to DBAL.
+            - [ ] Migrate `register/reset_password.php` to DBAL.
+            - [ ] Migrate `register/auth_check_header.php` to DBAL.
+            - [ ] Migrate `register/traffic.php` to DBAL.
+            - [ ] Migrate `register/router.php` to DBAL.
+            - [ ] Migrate `register/edit_user.php` to DBAL.
+            - [ ] Migrate `register/admin_index.php` to DBAL.
+            - [ ] Migrate `register/email_password_sender.php` to DBAL.
+            - [ ] Migrate `register/reset_password_save.php` to DBAL.
+            - [ ] Migrate `register/email_sent.php` to DBAL.
+            - [ ] Migrate `register/edit_user_save.php` to DBAL.
+            - [ ] Migrate `register/delete_user.php` to DBAL.
+            - [ ] Migrate `register/linktick.php` to DBAL.
+            - [x] **Migrate `register/checklogin.php` to DBAL**: (Completed: 2026-04-27) Updated to use the DBAL with prepared statements for the login query.
+            - [x] **Migrate `register/master_inc.php` to DBAL**: (Completed: 2026-04-27) Updated to use the DBAL for server connection and database selection.
         - [x] **Migrate `include/address.class.php` to DBAL**: (Completed: 2026-04-27) Updated the file to use the DBAL abstraction with prepared statements for CRUD operations and refactored the `Addresses` class to use DBAL query methods.
         - [x] **Migrate `include/group.class.php` and `group.php` to DBAL**: (Completed: 2026-04-27) Updated both files to use the DBAL abstraction with prepared statements for all database operations.
 

--- a/register/checklogin.php
+++ b/register/checklogin.php
@@ -1,64 +1,64 @@
-<?php
-
-include"login_config.php";
-
-//Connection String Variables_________________________________________________
-
-   // connect to the server
-   mysql_connect( $db_host, $db_username, $db_password )
-      or die( "Error! Could not connect to database: " . mysql_error() );
-   
-   // select the database
-   mysql_select_db( $db )
-      or die( "Error! Could not select the database: " . mysql_error() );
-
-//IBM suggested scrub for URL request
-$urlun = strip_tags(substr($_REQUEST['username'],0,32));
-$urlpw = strip_tags(substr($_REQUEST['password'],0,32));
-
-$cleanpw = md5($urlpw);
-
-//echo"Cleanpw: $cleanpw<br>";
-
-//$sql="SELECT * FROM agents WHERE username='$urlun' and password='$urlpw'";
-$sql="SELECT * FROM users WHERE username='$urlun' and password='$cleanpw'";
-
-$result=mysql_query($sql);
-
-// Mysql_num_row is counting table rows
-
-$count=mysql_num_rows($result);
-
-// If result matches $myusername and $mypassword, table row must be 1 row
-
-//echo"Count:$count<br>";
-
-if($count==1){
-
-// Register $myusername and redirect to file designated success file
-
-$cookie_name ="$cookiename";
-
-$cookie_value ="$urlun";
-
-//set to 24 hours
-
-$cookie_expire ="86400";
-
-setcookie($cookie_name,$cookie_value,time() + (86400),"/", $cookie_domain);
-
-header("location:$successful_login_url");
-
-}else{
-
-header("location:$failed_login");
-
-}
-
-
-?>
-
-
-
-
-
+<?php
+
+include"login_config.php";
+require_once __DIR__ . DIRECTORY_SEPARATOR . ".." . DIRECTORY_SEPARATOR . "include" . DIRECTORY_SEPARATOR . "mysqli.database.php";
+
+if(!isset($db_access)) {
+  $db_access = new MysqliDatabase();
+}
+
+//Connection String Variables_________________________________________________
+
+   // connect to the server
+   $db_access->connect( $db_host, $db_username, $db_password )
+      or die( "Error! Could not connect to database: " . $db_access->error() );
+
+   // select the database
+   $db_access->selectDb( $db )
+      or die( "Error! Could not select the database: " . $db_access->error() );
+
+//IBM suggested scrub for URL request
+$urlun = strip_tags(substr($_REQUEST['username'],0,32));
+$urlpw = strip_tags(substr($_REQUEST['password'],0,32));
+
+$cleanpw = md5($urlpw);
+
+//echo"Cleanpw: $cleanpw<br>";
+
+//$sql="SELECT * FROM agents WHERE username='$urlun' and password='$urlpw'";
+$sql="SELECT * FROM users WHERE username=? and password=?";
+
+$result=$db_access->execute($sql, array($urlun, $cleanpw));
+
+// Mysql_num_row is counting table rows
+
+$count=$db_access->numRows($result);
+
+// If result matches $myusername and $mypassword, table row must be 1 row
+
+//echo"Count:$count<br>";
+
+if($count==1){
+
+// Register $myusername and redirect to file designated success file
+
+$cookie_name ="$cookiename";
+
+$cookie_value ="$urlun";
+
+//set to 24 hours
+
+$cookie_expire ="86400";
+
+setcookie($cookie_name,$cookie_value,time() + (86400),"/", $cookie_domain);
+
+header("location:$successful_login_url");
+
+}else{
+
+header("location:$failed_login");
+
+}
+
+
+?>

--- a/register/master_inc.php
+++ b/register/master_inc.php
@@ -1,13 +1,18 @@
-<?
-//no space before <?
-  include"login_config.php";
-
-   // connect to the server
-   mysql_connect( $db_host, $db_username, $db_password )
-      or die( "Error! Could not connect to database: " . mysql_error() );
-   
-   // select the database
-   mysql_select_db( $db )
-      or die( "Error! Could not select the database: " . mysql_error() );
-	  
+<?php
+//no space before <?
+  include"login_config.php";
+  require_once __DIR__ . DIRECTORY_SEPARATOR . ".." . DIRECTORY_SEPARATOR . "include" . DIRECTORY_SEPARATOR . "mysqli.database.php";
+
+   if(!isset($db_access)) {
+     $db_access = new MysqliDatabase();
+   }
+
+   // connect to the server
+   $db_access->connect( $db_host, $db_username, $db_password )
+      or die( "Error! Could not connect to database: " . $db_access->error() );
+
+   // select the database
+   $db_access->selectDb( $db )
+      or die( "Error! Could not select the database: " . $db_access->error() );
+
 ?>


### PR DESCRIPTION
This change modernizes the database interaction in the registration module as part of the ongoing effort to remove legacy `mysql_*` functions. 

Key changes:
1. **Roadmap Refinement**: The broad "Migrate registration module" task in `MIGRATION_ROADMAP.md` has been broken down into 15 specific file-level tasks to better track progress and maintain the bottom-to-top execution order.
2. **Master Include Migration**: `register/master_inc.php` now uses the `MysqliDatabase` DBAL for connection and database selection, removing the direct calls to legacy functions.
3. **Login Logic Migration**: `register/checklogin.php` has been fully migrated to use the DBAL. Crucially, the login query now uses **prepared statements** to protect against SQL injection, a significant security improvement over the previous manual string concatenation.
4. **Consistency**: Both files now use `<?php` tags and follow the project's standard for locating shared includes using `__DIR__`.

Verification:
- Syntax checked with `php -l`.
- Verified the code review confirmed the logic and security improvements.
- Roadmap updated to mark completed steps.

Fixes #84

---
*PR created automatically by Jules for task [16226194235915759328](https://jules.google.com/task/16226194235915759328) started by @chatelao*