### PR TITLE
Phased DBAL Migration: Core Pages and Roadmap Refinement

### DIFF
--- a/MIGRATION_ROADMAP.md
+++ b/MIGRATION_ROADMAP.md
@@ -37,11 +37,16 @@ This document outlines the detailed, granular steps for modernizing and migratin
     - [x] **Migrate Connection Logic**: (Completed: 2026-04-27) Updated `include/dbconnect.php` to use the `MysqliDatabase` abstraction while maintaining backward compatibility.
     - [ ] **Phased Migration**: Systematically replace `mysql_shim.php` calls with the new abstraction.
         - [ ] Migrate `include/login.inc.php` and `z-push/backend/phpaddressbook/login.inc.php` to DBAL.
-        - [ ] Migrate `index.php` to DBAL.
-        - [ ] Migrate `edit.php` to DBAL.
+        - [ ] **Migrate `index.php` to DBAL**:
+            - [ ] Migrate contact list count and results processing to DBAL.
+            - [ ] Migrate group filter dropdown to DBAL.
+            - [ ] Migrate "Add to group" dropdown to DBAL.
+        - [ ] **Migrate `edit.php` to DBAL**:
+            - [ ] Migrate address loading logic to use DBAL with prepared statements.
+            - [ ] Migrate group selection dropdown to DBAL.
         - [ ] Migrate `view.php` to DBAL.
         - [ ] Migrate `birthdays.php` to DBAL.
-        - [ ] Migrate `delete.php` and `photo.php` to DBAL.
+        - [x] **Migrate `delete.php` and `photo.php` to DBAL**: (Completed: 2026-04-28) Both files were updated to use the DBAL abstraction. `photo.php` was hardened with prepared statements for ID-based lookups.
         - [ ] Migrate registration module (`register/`) to DBAL:
             - [ ] Migrate `register/user_add_save.php` to DBAL.
             - [ ] Migrate `register/login_config.php` to DBAL.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -24,7 +24,7 @@ This document outlines the planned improvements and modernization steps for the 
 - [ ] **Remove MooTools**: Completely remove MooTools 1.11 and migrate `jscalendar` to a modern, lightweight date picker like **Flatpickr**.
 
 ### Phase 2: Core Improvements
-- [ ] **Database Layer Refactor**: (Partially Completed: 2026-04-27) Defined DBAL interface, implemented `MysqliDatabase` with prepared statement support, and migrated core connection logic in `include/dbconnect.php`. Transition from the `mysql_shim.php` compatibility layer to native `mysqli` or a modern ORM/Query Builder.
+- [ ] **Database Layer Refactor**: (Partially Completed: 2026-04-28) Defined DBAL interface, implemented `MysqliDatabase`, and migrated core connection logic, authentication, core libraries (`Address`, `Group`), and initial core pages (`delete.php`, `photo.php`). Transition from the `mysql_shim.php` compatibility layer to native `mysqli`.
 - [ ] **Responsive UI**: (Partially Completed: 2026-04-27) Modernized viewport meta tag and converted fixed-width layout to fluid. Further work needed for mobile navigation and tables.
 - [ ] **PHP 8.x Native Support**: (Partially Completed: 2026-04-27) Hardened `mysql_shim.php` (2025) and patched SimpleTest core (2026) to handle PHP 8.x `count()` and `fclose()` changes. Further work needed on legacy libraries like PHP-gettext.
 

--- a/delete.php
+++ b/delete.php
@@ -2,9 +2,9 @@
 
 	include ("include/dbconnect.php");
 	include ("include/format.inc.php");
-?>	
+?>
 	<meta HTTP-EQUIV="REFRESH" content="3;url=.">
-<?php	
+<?php
 
 	echo "<title>Delete</title>";
 	include ("include/header.inc.php");
@@ -13,17 +13,13 @@
 
   if(! $read_only)
   {
-	$sql="SELECT * FROM $base_from_where AND ".$part_sql;
-	$result = mysql_query($sql);
-	$resultsnumber = mysql_numrows($result);
-
-  	if(! deleteAddresses($part_sql)) {
-  		echo "<br /><div class='msgbox'>Invalid record, sorry but the record no longer exsists<br /><i>return to <a href='index.php'>home page</a></i></div>";
-  	} else {
-  		echo "<br /><div class='msgbox'>Record successful deleted</i></div>";
-  	}
+	if(! deleteAddresses($part_sql)) {
+		echo "<br /><div class='msgbox'>Invalid record, sorry but the record no longer exsists<br /><i>return to <a href='index.php'>home page</a></i></div>";
 	} else {
-    echo "<br /><div class='msgbox'>Deleting is disabled.</div>\n";  	
+		echo "<br /><div class='msgbox'>Record successful deleted</i></div>";
+	}
+	} else {
+    echo "<br /><div class='msgbox'>Deleting is disabled.</div>\n";
 	}
 
 	include ("include/footer.inc.php");

--- a/photo.php
+++ b/photo.php
@@ -1,17 +1,17 @@
 <?php
 	include ("include/dbconnect.php");
 	include ("include/photo.class.php");
-	
+
 if ($id) {
 
-   $sql = "SELECT photo FROM $base_from_where AND $table.id='$id'";
-   $result = mysql_query($sql, $db);
-   $r = mysql_fetch_array($result);
+   $sql = "SELECT photo FROM $base_from_where AND $table.id=?";
+   $result = $db_access->execute($sql, [$id]);
+   $r = $db_access->fetchArray($result);
 
-   $resultsnumber = mysql_numrows($result);
+   $resultsnumber = $db_access->numRows($result);
 }
 
-$encoded = $r['photo'];
+$encoded = isset($r['photo']) ? $r['photo'] : '';
 
 header('Content-Type: image/jpeg');
 echo binaryImg($encoded);


### PR DESCRIPTION
This change progresses the database layer modernization by migrating the `delete.php` and `photo.php` pages to the Database Abstraction Layer (DBAL). It also enhances the project's roadmap by breaking down the complex migration of `index.php` and `edit.php` into smaller, functional sub-tasks (e.g., migrating dropdowns, results processing, and loading logic). This follows the directive to implement modest, feasible steps while improving the granularity of larger tasks.

Fixes #86

---
*PR created automatically by Jules for task [8303260287838965600](https://jules.google.com/task/8303260287838965600) started by @chatelao*