### PR TITLE
Migrate birthdays.php to DBAL

### DIFF
--- a/MIGRATION_ROADMAP.md
+++ b/MIGRATION_ROADMAP.md
@@ -45,7 +45,7 @@ This document outlines the detailed, granular steps for modernizing and migratin
             - [ ] Migrate address loading logic to use DBAL with prepared statements.
             - [ ] Migrate group selection dropdown to DBAL.
         - [ ] Migrate `view.php` to DBAL.
-        - [ ] Migrate `birthdays.php` to DBAL.
+        - [x] **Migrate `birthdays.php` to DBAL**: (Completed: 2026-04-28) Updated the file to use the DBAL abstraction for database queries and results processing.
         - [x] **Migrate `delete.php` and `photo.php` to DBAL**: (Completed: 2026-04-28) Both files were updated to use the DBAL abstraction. `photo.php` was hardened with prepared statements for ID-based lookups.
         - [ ] Migrate registration module (`register/`) to DBAL:
             - [ ] Migrate `register/user_add_save.php` to DBAL.

--- a/birthdays.php
+++ b/birthdays.php
@@ -86,10 +86,10 @@ FROM $month_lookup,
 $base_from_where AND $table.bmonth = $month_lookup.bmonth AND $table.bday > 0
 ORDER BY prio ASC;";
 
-	$result = mysql_query($sql);
-	$resultsnumber = mysql_num_rows($result);
+	$result = $db_access->query($sql);
+	$resultsnumber = $db_access->numRows($result);
 
-	while ($myrow = mysql_fetch_array($result))
+	while ($myrow = $db_access->fetchArray($result))
 	{
 		$firstname  = $myrow["firstname"];
 		$id         = $myrow["id"];


### PR DESCRIPTION
Migrated `birthdays.php` to use the Database Abstraction Layer (DBAL). This involved replacing legacy `mysql_*` function calls with methods from the `$db_access` object, as part of the phased migration outlined in `MIGRATION_ROADMAP.md`. Verified the changes for syntax errors and confirmed that no legacy MySQL calls remain in the file. Reverted accidental changes to `config/cfg.db.php`.

Fixes #88

---
*PR created automatically by Jules for task [3936653096847340986](https://jules.google.com/task/3936653096847340986) started by @chatelao*