### PR TITLE
Migrate core pages (index, view, edit) to DBAL

### DIFF
--- a/MIGRATION_ROADMAP.md
+++ b/MIGRATION_ROADMAP.md
@@ -36,15 +36,15 @@ This document outlines the detailed, granular steps for modernizing and migratin
         - [x] **Implement support for prepared statements in the DBAL**: (Completed: 2026-04-27) Added `execute` method to `DatabaseInterface` and implemented it in `MysqliDatabase` using `mysqli_execute_query` with a fallback for PHP < 8.2.
     - [x] **Migrate Connection Logic**: (Completed: 2026-04-27) Updated `include/dbconnect.php` to use the `MysqliDatabase` abstraction while maintaining backward compatibility.
     - [ ] **Phased Migration**: Systematically replace `mysql_shim.php` calls with the new abstraction.
-        - [ ] Migrate `include/login.inc.php` and `z-push/backend/phpaddressbook/login.inc.php` to DBAL.
-        - [ ] **Migrate `index.php` to DBAL**:
-            - [ ] Migrate contact list count and results processing to DBAL.
-            - [ ] Migrate group filter dropdown to DBAL.
-            - [ ] Migrate "Add to group" dropdown to DBAL.
-        - [ ] **Migrate `edit.php` to DBAL**:
-            - [ ] Migrate address loading logic to use DBAL with prepared statements.
-            - [ ] Migrate group selection dropdown to DBAL.
-        - [ ] Migrate `view.php` to DBAL.
+        - [x] **Migrate `include/login.inc.php` and `z-push/backend/phpaddressbook/login.inc.php` to DBAL**: (Completed: 2026-04-28) Both files were updated to use the DBAL `execute` method for prepared statements in authentication logic.
+        - [x] **Migrate `index.php` to DBAL**: (Completed: 2026-04-28)
+            - [x] Migrate contact list count and results processing to DBAL.
+            - [x] Migrate group filter dropdown to DBAL.
+            - [x] Migrate "Add to group" dropdown to DBAL.
+        - [x] **Migrate `edit.php` to DBAL**: (Completed: 2026-04-28)
+            - [x] Migrate address loading logic to use DBAL via Addresses class.
+            - [x] Migrate group selection dropdown to DBAL.
+        - [x] **Migrate `view.php` to DBAL**: (Completed: 2026-04-28) Both single entry and 'all' views migrated.
         - [x] **Migrate `birthdays.php` to DBAL**: (Completed: 2026-04-28) Updated the file to use the DBAL abstraction for database queries and results processing.
         - [x] **Migrate `delete.php` and `photo.php` to DBAL**: (Completed: 2026-04-28) Both files were updated to use the DBAL abstraction. `photo.php` was hardened with prepared statements for ID-based lookups.
         - [ ] Migrate registration module (`register/`) to DBAL:

--- a/edit.php
+++ b/edit.php
@@ -11,11 +11,12 @@ if($submit || $update) { ?>
 $resultsnumber = 0;
 if ($id) {
 
-   $sql = "SELECT * FROM $base_from_where AND $table.id='$id'";
-   $result = mysql_query($sql, $db);
-   $r = mysql_fetch_array($result);
-
-   $resultsnumber = mysql_numrows($result);
+   $addresses = Addresses::withID($id);
+   $resultsnumber = $addresses->count();
+   if($resultsnumber > 0) {
+     $addr_obj = $addresses->nextAddress();
+     $r = $addr_obj->getData();
+   }
 }
 
 if( ($resultsnumber == 0 && !isset($all)) || (!$id && !isset($all))) {
@@ -178,8 +179,9 @@ else if($id)
 {
   if(! $read_only)
   {
-$result = mysql_query("SELECT * FROM $base_from_where AND $table.id=$id",$db);
-$myrow = mysql_fetch_array($result);
+$addresses = Addresses::withID($id);
+$addr_obj = $addresses->nextAddress();
+$myrow = $addr_obj->getData();
 ?>
 
   <form enctype="multipart/form-data" 
@@ -365,10 +367,9 @@ $myrow = mysql_fetch_array($result);
             echo "<option>$group_name</option>\n";
           }
           $sql = "SELECT group_name FROM $table_groups ORDER BY lower(group_name) ASC";
-          $result_groups = mysql_query($sql);
-          $result_gropup_snumber = mysql_numrows($result_groups);
+          $result_groups = $db_access->query($sql);
           
-          while ($myrow_group = mysql_fetch_array($result_groups))
+          while ($myrow_group = $db_access->fetchArray($result_groups))
           {
             echo "<option>".$myrow_group["group_name"]."</option>\n";
           }
@@ -693,10 +694,9 @@ function proposeNames() {
           <option value="[none]">[<?php echo msg("NONE"); ?>]</option>
           <?php
           $sql="SELECT group_name FROM $groups_from_where ORDER BY lower(group_name) ASC";
-          $result_groups = mysql_query($sql);
-          $result_gropup_snumber = mysql_numrows($result_groups);
+          $result_groups = $db_access->query($sql);
           
-          while ($myrow_group = mysql_fetch_array($result_groups))
+          while ($myrow_group = $db_access->fetchArray($result_groups))
           {
             echo "<option>".$myrow_group["group_name"]."</option>\n";
           }

--- a/index.php
+++ b/index.php
@@ -48,8 +48,7 @@ echo "<div id='a-z'><a href='$link=a'>A</a> | <a href='$link=b'>B</a> | <a href=
 <?php
 
   $addresses = Addresses::withSearchString($searchstring, $alphabet);
-  $result = $addresses->getResults();
-	$resultsnumber = mysql_numrows($result);
+	$resultsnumber = $addresses->count();
 	
 	// TBD:  Pagination
 	// http://php.about.com/od/phpwithmysql/ss/php_pagination.htm
@@ -69,10 +68,9 @@ if(isset($table_groups) and $table_groups != "" and !$is_fix_group) { ?>
 		<option value="[none]">[<?php echo msg("NONE"); ?>]</option>
 		<?php
 			$sql="SELECT group_name FROM $groups_from_where ORDER BY lower(group_name) ASC";
-			$result_groups = mysql_query($sql);
-			$result_gropup_snumber = mysql_numrows($result_groups);
+			$result_groups = $db_access->query($sql);
 	
-			while ($myrow = mysql_fetch_array($result_groups))
+			while ($myrow = $db_access->fetchArray($result_groups))
 			{
 			echo "<option>".$myrow["group_name"]."</option>\n";
 			}
@@ -287,10 +285,9 @@ function addRow($row) {
       echo "<select name='to_group'>";
     
 	  	$sql="SELECT group_name FROM $groups_from_where ORDER BY lower(group_name) ASC";
-	  	$result = mysql_query($sql);
-	  	$resultsnumber = mysql_numrows($result);
+		$result = $db_access->query($sql);
 	  
-	  	while ($myrow = mysql_fetch_array($result))
+		while ($myrow = $db_access->fetchArray($result))
 	  	{
 	  		echo "<option>".$myrow["group_name"]."</option>\n";
 	  	}

--- a/view.php
+++ b/view.php
@@ -5,11 +5,12 @@
 $resultsnumber = 0;
 if ($id) {
 
-   $sql = "SELECT * FROM $base_from_where AND $table.id='$id'";
-   $result = mysql_query($sql, $db);
-   $r = mysql_fetch_array($result);
-
-   $resultsnumber = mysql_numrows($result);
+   $addresses = Addresses::withID($id);
+   $resultsnumber = $addresses->count();
+   if($resultsnumber > 0) {
+     $addr = $addresses->nextAddress();
+     $r = $addr->getData();
+   }
 }
 
 if( ($resultsnumber == 0 && !isset($all)) || (!$id && !isset($all))) {
@@ -41,10 +42,10 @@ if($resultsnumber == 0) {
 include "include/view.w.php";
 showOneEntry($r);
 
-?>	
+?>
 <br />
 <br />
-<?php if( !isset($_GET["print"])) 
+<?php if( !isset($_GET["print"]))
 { ?>
 <form method="get" action="edit<?php echo $page_ext; ?>">
     <input type="hidden" name="id" value="<?php echo $id; ?>" />
@@ -66,7 +67,7 @@ showOneEntry($r);
    include "include/view.w.php";
 
    $sql = "SELECT * FROM $base_from_where order by lastname, firstname";
-   $result = mysql_query($sql, $db);
+   $result = $db_access->query($sql);
 
 	 $cnt = 0;
 	 echo "<h1>".ucfmsg('ADDRESS_BOOK').($group ? " ".msg('FOR')." <i>$group</i></h1>" : "</h1>");
@@ -74,32 +75,32 @@ showOneEntry($r);
    <table id="view">
 
    <?php
-   
+
    $only_phones = isset($_REQUEST['phones']);
 
    $addr_per_line  = ($only_phones ? 4 : 3);
-   
-   while($r = mysql_fetch_array($result)) {
-   	 $r = trimAll($r);   	
-   	 $address = new Address($r);
-   	 if($address->hasPhone() || !$only_phones) {
+
+   while($r = $db_access->fetchArray($result)) {
+	 $r = trimAll($r);
+	 $address = new Address($r);
+	 if($address->hasPhone() || !$only_phones) {
        if( ($cnt % (2*$addr_per_line)) == 0)
-       		echo "<tr class='odd'>";
+		echo "<tr class='odd'>";
        if( ($cnt % (2*$addr_per_line)) == $addr_per_line)
-       		echo "<tr class='even'>";
-       		
+		echo "<tr class='even'>";
+
        echo "<td valign='top'>";
-   	   showOneEntry($r, $only_phones);
+	   showOneEntry($r, $only_phones);
        echo "</td>";
 
        $cnt++;
        if( ($cnt % $addr_per_line) == 0)
-       		echo "</tr>";       	
-     }	
+		echo "</tr>";
+     }
    }
    while(($cnt % $addr_per_line) != 0)
    {
-      echo "<td>.</td>";   	
+      echo "<td>.</td>";
       $cnt++;
    }
    ?>


### PR DESCRIPTION
Migrated `index.php`, `view.php`, and `edit.php` to use the Database Abstraction Layer (DBAL). This involves replacing legacy `mysql_*` functions with the modern `$db_access` object methods and the `Addresses` class. Additionally, the `MIGRATION_ROADMAP.md` has been updated to track the completion of these migrations and the previously completed authentication migration. All development artifacts have been removed and files were verified for syntax errors.

Fixes #90

---
*PR created automatically by Jules for task [134506931736481073](https://jules.google.com/task/134506931736481073) started by @chatelao*